### PR TITLE
Fix: Ensure Zed always has lowest priority in AI tool detection

### DIFF
--- a/executable_gh
+++ b/executable_gh
@@ -136,16 +136,6 @@ check_ps_tree() {
             break
         fi
 
-        # Check for AI tool patterns
-        if [ -n "$GEMINI_CLI" ]; then
-            echo "gemini"
-            return
-        fi
-        if [ -n "$QWEN_CODE" ]; then
-            echo "qwen"
-            return
-        fi
-
         debug_log "Checking PID $current_pid at depth $depth"
 
         if process_contains "$current_pid" "claude"; then

--- a/test_priority_order.sh
+++ b/test_priority_order.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+# Test script to verify AI tool priority order
+# Ensures that Zed always comes last in priority
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+print_test() {
+    echo -e "${CYAN}[TEST]${NC} $*"
+}
+
+print_pass() {
+    echo -e "${GREEN}[PASS]${NC} $*"
+}
+
+print_fail() {
+    echo -e "${RED}[FAIL]${NC} $*"
+    exit 1
+}
+
+# Find the gh wrapper
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GH_WRAPPER="$SCRIPT_DIR/executable_gh"
+
+if [ ! -f "$GH_WRAPPER" ]; then
+    print_fail "executable_gh not found at $GH_WRAPPER"
+fi
+
+echo ""
+echo -e "${BLUE}=== AI Tool Priority Order Tests ===${NC}"
+echo ""
+echo "Expected priority: Amp > Codex > Claude > Gemini > Qwen > Droid > OpenCode > Cursor > Kimi > Copilot > Zed"
+echo ""
+
+# Helper function to test detection
+test_detection() {
+    local test_name="$1"
+    local expected="$2"
+    shift 2
+    local env_vars=("$@")
+
+    print_test "$test_name"
+
+    # Build env command
+    local env_cmd=""
+    for var in "${env_vars[@]}"; do
+        env_cmd="$env_cmd $var"
+    done
+
+    # Run gh wrapper with debug mode and capture AI detection
+    local output
+    output=$(env GH_AI_DEBUG=true $env_cmd "$GH_WRAPPER" --version 2>&1 || true)
+
+    # Extract detected AI tool from debug output
+    local detected=""
+    if echo "$output" | grep -q "AI detected:"; then
+        detected=$(echo "$output" | grep "AI detected:" | sed 's/.*AI detected: \([^ ]*\).*/\1/')
+    elif echo "$output" | grep -q "No AI detected"; then
+        detected="none"
+    fi
+
+    if [ "$detected" = "$expected" ]; then
+        print_pass "Correctly detected '$expected'"
+        return 0
+    else
+        print_fail "Expected '$expected', got '$detected'"
+        return 1
+    fi
+}
+
+# Test 1: Only Zed detected
+test_detection "Only Zed" "zed" "ZED_TERM=true"
+
+# Test 2: Zed + Gemini (Gemini should win)
+test_detection "Zed + Gemini" "gemini" "ZED_TERM=true" "GEMINI_CLI=1"
+
+# Test 3: Zed + Cursor (Cursor should win)
+test_detection "Zed + Cursor" "cursor" "ZED_TERM=true" "CURSOR_AI=1"
+
+# Test 4: Zed + Kimi (Kimi should win)
+test_detection "Zed + Kimi" "kimi" "ZED_TERM=true" "KIMI_CLI=1"
+
+# Test 5: Zed + Codex (Codex should win)
+test_detection "Zed + Codex" "codex" "ZED_TERM=true" "CODEX_CLI=1"
+
+# Test 6: Zed + OpenCode (OpenCode should win)
+test_detection "Zed + OpenCode" "opencode" "ZED_TERM=true" "OPENCODE_AI=1"
+
+# Test 7: Zed + Qwen (Qwen should win)
+test_detection "Zed + Qwen" "qwen" "ZED_TERM=true" "QWEN_CODE=1"
+
+# Test 8: Zed + Amp (Amp should win - highest priority)
+test_detection "Zed + Amp" "amp" "ZED_TERM=true" "AMP_HOME=/tmp/amp"
+
+# Test 9: Multiple tools including Zed (Codex should win as highest priority present)
+test_detection "Codex + Gemini + Zed" "codex" "ZED_TERM=true" "GEMINI_CLI=1" "CODEX_CLI=1"
+
+# Test 10: Priority order verification - Claude > Gemini
+test_detection "Claude + Gemini" "claude" "CLAUDECODE=1" "CLAUDE_CODE_ENTRYPOINT=cli" "GEMINI_CLI=1"
+
+# Test 11: Priority order verification - Gemini > Qwen
+test_detection "Gemini + Qwen" "gemini" "GEMINI_CLI=1" "QWEN_CODE=1"
+
+# Test 12: Priority order verification - Cursor > Kimi
+test_detection "Cursor + Kimi" "cursor" "CURSOR_AI=1" "KIMI_CLI=1"
+
+echo ""
+echo -e "${GREEN}=== All Priority Order Tests Passed! ===${NC}"
+echo ""
+echo "✓ Zed is correctly prioritized last"
+echo "✓ All higher-priority tools are selected over Zed when present"
+echo "✓ Priority order is correctly enforced: Amp > Codex > Claude > Gemini > Qwen > Droid > OpenCode > Cursor > Kimi > Copilot > Zed"
+echo ""


### PR DESCRIPTION
## Summary

Fixes the AI tool priority order to ensure Zed is always selected last, as documented. The fix removes problematic early returns in `check_ps_tree()` that could bypass higher-priority tool detection.

## Changes

1. **Removed redundant environment variable checks** in `check_ps_tree()` that caused early returns
   - These checks duplicated logic already in `check_env_vars()`
   - The early returns prevented higher-priority tools from being detected in the process tree
   - For example, if `QWEN_CODE=1` was set but Claude was in the process tree, Claude would never be detected

2. **Added comprehensive test suite** (`test_priority_order.sh`)
   - Tests verify that Zed is only selected when no other tools are present
   - Tests verify priority order is enforced: Amp > Codex > Claude > Gemini > Qwen > Droid > OpenCode > Cursor > Kimi > Copilot > Zed
   - Tests verify that when multiple tools are detected, the highest priority tool wins

## Why This Matters

The priority order is critical because:
- **Zed often hosts other AI tools** (e.g., Claude running in Zed terminal)
- When multiple tools are present, we should attribute to the primary AI tool, not the terminal/editor
- The comment in the code explicitly states "Zed is last because it often hosts other AI tools"

## Testing

Verified the fix works correctly by running in Claude Code inside a Zed terminal:
```
Combined detected: ' claude zed  claude zed claude claude'
Final result: claude
```

This shows both tools are detected, but Claude is correctly prioritized over Zed.

## Test Plan

- [x] Run `test_priority_order.sh` to verify priority order
- [x] Test with debug mode: `GH_AI_DEBUG=true ZED_TERM=true gh --version`
- [x] Verify Zed is detected when it's the only tool present
- [x] Verify higher-priority tools are selected over Zed when both are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)