### PR TITLE
feat: add support for detecting and attributing Aider AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Force AI detection for testing:
 
 ```bash
 # Simulate different AI environments
+OR_APP_NAME=Aider gh issue list
 CLAUDE_CODE=1 gh issue list
 CURSOR_AI=1 gh pr view 123
 GEMINI_CLI=1 gh repo clone user/repo
@@ -128,14 +129,18 @@ The wrapper automatically detects:
 
 | AI Tool | Detection Method | Environment Variable |
 |---------|------------------|---------------------|
+| [Aider](https://aider.chat/) | Process name + env | `OR_APP_NAME=Aider` |
+| Amp (Sourcegraph) | Process name + env | `AGENT=amp`, `AMP_HOME` |
 | Claude (Anthropic) | Process name + env | `CLAUDE_CODE`, `ANTHROPIC_SHELL` |
+| Codex CLI (OpenAI) | Process name + env | `CODEX_CLI` |
 | Cursor | Process name + env | `CURSOR_AI` |
+| Droid (Factory AI) | Process name + env | `DROID_CLI` |
 | Gemini (Google) | Process name + env | `GEMINI_CLI` |
+| GitHub Copilot CLI | Process name + env | `GITHUB_COPILOT_CLI_MODE=true` |
+| Kimi CLI | Process name + env | `KIMI_CLI` |
+| OpenCode | Process name + env | `OPENCODE_AI` |
 | Qwen Code (Alibaba) | Process name + env | `QWEN_CODE` |
 | Zed AI | Process name + env | `ZED_AI` |
-| OpenCode | Process name + env | `OPENCODE_AI` |
-| Codex CLI (OpenAI) | Process name + env | `CODEX_CLI` |
-| Kimi CLI | Process name + env | `KIMI_CLI` |
 
 ## ⚙️ Configuration
 

--- a/executable_gh
+++ b/executable_gh
@@ -77,6 +77,12 @@ check_env_vars() {
         debug_log "Detected Codex via environment variable"
     fi
 
+    # Aider detection
+    if [ "$OR_APP_NAME" = "Aider" ]; then
+        detected="$detected aider"
+        debug_log "Detected Aider via environment variable"
+    fi
+
     # Zed detection (environment variables are always present in Zed terminals)
     # We'll rely more on process tree for Zed
     if [ "$TERM_PROGRAM" = "zed" ] || [ "$ZED_TERM" = "true" ]; then
@@ -150,6 +156,10 @@ check_ps_tree() {
             detected="$detected codex"
             debug_log "Detected Codex in process tree at depth $depth"
         fi
+        if process_contains "$current_pid" "aider"; then
+            detected="$detected aider"
+            debug_log "Detected Aider in process tree at depth $depth"
+        fi
         if process_contains "$current_pid" "qwen"; then
             detected="$detected qwen"
             debug_log "Detected Qwen in process tree at depth $depth"
@@ -221,7 +231,7 @@ detect_ai_tool() {
     debug_log "Process tree detected: '$ps_detected'"
     debug_log "Combined detected: '$all_detected'"
 
-    # Priority order: Amp > Codex > Claude > Gemini > Qwen > Droid > OpenCode > Cursor > Kimi > Copilot > Zed
+    # Priority order: Amp > Codex > Aider > Claude > Gemini > Qwen > Droid > OpenCode > Cursor > Kimi > Copilot > Zed
     # Zed is last because it often hosts other AI tools
     if [[ "$all_detected" =~ "amp" ]]; then
         debug_log "Final result: amp"
@@ -229,6 +239,9 @@ detect_ai_tool() {
     elif [[ "$all_detected" =~ "codex" ]]; then
         debug_log "Final result: codex"
         echo "codex"
+    elif [[ "$all_detected" =~ "aider" ]]; then
+        debug_log "Final result: aider"
+        echo "aider"
     elif [[ "$all_detected" =~ "claude" ]]; then
         debug_log "Final result: claude"
         echo "claude"

--- a/test_ai_detection.sh
+++ b/test_ai_detection.sh
@@ -25,6 +25,7 @@ echo "QWEN_CODE: '$QWEN_CODE'"
 echo "CURSOR_AI: '$CURSOR_AI'"
 echo "OPENCODE_AI: '$OPENCODE_AI'"
 echo "CODEX_CLI: '$CODEX_CLI'"
+echo "OR_APP_NAME: '$OR_APP_NAME'"
 
 echo -e "\n=== Environment Detection ==="
 env_result=$(check_env_vars)


### PR DESCRIPTION
## Summary

Adds detection for [Aider](https://aider.chat/) AI tool, enabling proper attribution when Aider uses the GitHub CLI through this wrapper.

This change mirrors the implementation from [ai-aligned-git PR #32](https://github.com/trieloff/ai-aligned-git/pull/32), bringing Aider support to the GitHub CLI wrapper.

Closes #27
Related to #26

## Changes

- ✅ Add Aider environment variable detection (`OR_APP_NAME=Aider`)
- ✅ Add Aider process tree detection (searches for "aider" in process names)
- ✅ Place Aider in priority order after Codex, before Claude
- ✅ Update README with Aider in supported AI tools table
- ✅ Add Aider to test examples in README
- ✅ Update test_ai_detection.sh to check `OR_APP_NAME` variable

## How Aider Detection Works

Aider sets `OR_APP_NAME=Aider` in its environment, which is detected by:

1. **Environment variable check**: Looks for `OR_APP_NAME=Aider`
2. **Process tree check**: Searches for "aider" in parent process names

## Priority Order

The detection priority is now:
Amp > Codex > **Aider** > Claude > Gemini > Qwen > Droid > OpenCode > Cursor > Kimi > Copilot > Zed

## Testing

Tested with:
```bash
OR_APP_NAME=Aider ./test_ai_detection.sh
```

Result: Successfully detects Aider and gives it proper priority over other AI tools (except Amp and Codex).

## Attribution

When Aider is detected and performs GitHub operations, they will be properly attributed via the as-a-bot service, showing actions as performed on behalf of the user rather than appearing to come directly from the user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)