### PR TITLE
feat: add support for detecting and attributing Crush AI agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ The wrapper automatically detects:
 | Amp (Sourcegraph) | Process name + env | `AGENT=amp`, `AMP_HOME` |
 | Claude (Anthropic) | Process name + env | `CLAUDE_CODE`, `ANTHROPIC_SHELL` |
 | Codex CLI (OpenAI) | Process name + env | `CODEX_CLI` |
+| [Crush](https://charm.sh/tools/crush/) (Charm) | Process name only | (detected via process tree) |
 | Cursor | Process name + env | `CURSOR_AI` |
 | Droid (Factory AI) | Process name + env | `DROID_CLI` |
 | Gemini (Google) | Process name + env | `GEMINI_CLI` |

--- a/executable_gh
+++ b/executable_gh
@@ -114,6 +114,9 @@ check_env_vars() {
         debug_log "Detected Kimi CLI via environment variable"
     fi
 
+    # Crush detection (no environment variables, relies on process tree)
+    # Note: Crush is typically detected via process tree only
+
     echo "$detected"
 }
 
@@ -191,6 +194,11 @@ check_ps_tree() {
             detected="$detected kimi"
             debug_log "Detected Kimi CLI in process tree at depth $depth"
         fi
+        # Crush detection - look for crush in process command
+        if process_contains "$current_pid" "crush"; then
+            detected="$detected crush"
+            debug_log "Detected Crush in process tree at depth $depth"
+        fi
         # Droid detection - use word boundary to avoid matching android-studio, etc.
         if [[ "$OSTYPE" == "darwin"* ]]; then
             if ps -p "$current_pid" -o comm= 2>/dev/null | grep -qiw "droid" || \
@@ -231,8 +239,9 @@ detect_ai_tool() {
     debug_log "Process tree detected: '$ps_detected'"
     debug_log "Combined detected: '$all_detected'"
 
-    # Priority order: Amp > Codex > Aider > Claude > Gemini > Qwen > Droid > OpenCode > Cursor > Kimi > Copilot > Zed
+    # Priority order: Amp > Codex > Aider > Claude > Gemini > Qwen > Droid > OpenCode > Cursor > Kimi > Copilot > Crush > Zed
     # Zed is last because it often hosts other AI tools
+    # Crush takes precedence over Zed but after other AI tools
     if [[ "$all_detected" =~ "amp" ]]; then
         debug_log "Final result: amp"
         echo "amp"
@@ -266,6 +275,9 @@ detect_ai_tool() {
     elif [[ "$all_detected" =~ "copilot" ]]; then
         debug_log "Final result: copilot"
         echo "copilot"
+    elif [[ "$all_detected" =~ "crush" ]]; then
+        debug_log "Final result: crush"
+        echo "crush"
     elif [[ "$all_detected" =~ "zed" ]]; then
         debug_log "Final result: zed"
         echo "zed"

--- a/test_ai_detection.sh
+++ b/test_ai_detection.sh
@@ -26,6 +26,7 @@ echo "CURSOR_AI: '$CURSOR_AI'"
 echo "OPENCODE_AI: '$OPENCODE_AI'"
 echo "CODEX_CLI: '$CODEX_CLI'"
 echo "OR_APP_NAME: '$OR_APP_NAME'"
+echo "Note: Crush has no environment variables, detected via process tree only"
 
 echo -e "\n=== Environment Detection ==="
 env_result=$(check_env_vars)


### PR DESCRIPTION
## Summary

Adds detection for [Crush](https://charm.sh/tools/crush/) AI agent from Charm, enabling proper attribution when Crush uses the GitHub CLI through this wrapper.

This change mirrors the implementation from [ai-aligned-git PR #29](https://github.com/trieloff/ai-aligned-git/pull/29), bringing Crush support to the GitHub CLI wrapper.

Closes #29
Related to #26

## Changes

- ✅ Add Crush process tree detection (searches for "crush" in process names)
- ✅ Add comment noting Crush has no environment variables
- ✅ Place Crush in priority order after Copilot, before Zed
- ✅ Update README with Crush in supported AI tools table
- ✅ Add note to test_ai_detection.sh about Crush detection method

## How Crush Detection Works

Unlike most other AI tools, Crush does **not** set any specific environment variables. Detection relies solely on process tree analysis:

- **Process tree check**: Searches for "crush" in parent process names

This is similar to how Droid is detected, using process name matching.

## Priority Order

The detection priority is now:
Amp > Codex > Aider > Claude > Gemini > Qwen > Droid > OpenCode > Cursor > Kimi > Copilot > **Crush** > Zed

Crush is placed before Zed (which often hosts other AI tools) but after most other AI coding assistants.

## Testing

Tested with the updated test script:
```bash
./test_ai_detection.sh
```

Note: Since Crush doesn't set environment variables, it can only be detected when actually running within a Crush process context.

## Attribution

When Crush is detected and performs GitHub operations, they will be properly attributed via the as-a-bot service, showing actions as performed on behalf of the user rather than appearing to come directly from the user.

💘 Generated with [Claude Code](https://claude.com/claude-code)