### PR TITLE
Add detection for Goose AI coding agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ The wrapper automatically detects:
 | Cursor | Process name + env | `CURSOR_AI` |
 | Droid (Factory AI) | Process name + env | `DROID_CLI` |
 | Gemini (Google) | Process name + env | `GEMINI_CLI` |
+| [Goose](https://github.com/block/goose) (Block) | Process name + env | `GOOSE_TERMINAL` |
 | GitHub Copilot CLI | Process name + env | `GITHUB_COPILOT_CLI_MODE=true` |
 | Kimi CLI | Process name + env | `KIMI_CLI` |
 | OpenCode | Process name + env | `OPENCODE_AI` |

--- a/executable_gh
+++ b/executable_gh
@@ -117,6 +117,12 @@ check_env_vars() {
     # Crush detection (no environment variables, relies on process tree)
     # Note: Crush is typically detected via process tree only
 
+    # Goose detection (Block)
+    if [ -n "$GOOSE_TERMINAL" ]; then
+        detected="$detected goose"
+        debug_log "Detected Goose via environment variable"
+    fi
+
     echo "$detected"
 }
 
@@ -199,6 +205,11 @@ check_ps_tree() {
             detected="$detected crush"
             debug_log "Detected Crush in process tree at depth $depth"
         fi
+        # Goose detection - look for goose in process command
+        if process_contains "$current_pid" "goose"; then
+            detected="$detected goose"
+            debug_log "Detected Goose in process tree at depth $depth"
+        fi
         # Droid detection - use word boundary to avoid matching android-studio, etc.
         if [[ "$OSTYPE" == "darwin"* ]]; then
             if ps -p "$current_pid" -o comm= 2>/dev/null | grep -qiw "droid" || \
@@ -239,9 +250,10 @@ detect_ai_tool() {
     debug_log "Process tree detected: '$ps_detected'"
     debug_log "Combined detected: '$all_detected'"
 
-    # Priority order: Amp > Codex > Aider > Claude > Gemini > Qwen > Droid > OpenCode > Cursor > Kimi > Copilot > Crush > Zed
+    # Priority order: Amp > Codex > Aider > Claude > Gemini > Qwen > Droid > OpenCode > Cursor > Kimi > Copilot > Crush > Goose > Zed
     # Zed is last because it often hosts other AI tools
     # Crush takes precedence over Zed but after other AI tools
+    # Goose comes after Crush but before Zed
     if [[ "$all_detected" =~ "amp" ]]; then
         debug_log "Final result: amp"
         echo "amp"
@@ -278,6 +290,9 @@ detect_ai_tool() {
     elif [[ "$all_detected" =~ "crush" ]]; then
         debug_log "Final result: crush"
         echo "crush"
+    elif [[ "$all_detected" =~ "goose" ]]; then
+        debug_log "Final result: goose"
+        echo "goose"
     elif [[ "$all_detected" =~ "zed" ]]; then
         debug_log "Final result: zed"
         echo "zed"
@@ -785,7 +800,7 @@ check_as_a_bot_status() {
 
     # Check token type
     if [[ "$cached_token" == ghu_* ]]; then
-        echo "  Status: Authenticated ✓" >&2
+        echo "  Status: Authenticated ?" >&2
         echo "  Token type: User-to-server (ghu_)" >&2
         echo "" >&2
 

--- a/test_ai_detection.sh
+++ b/test_ai_detection.sh
@@ -26,6 +26,7 @@ echo "CURSOR_AI: '$CURSOR_AI'"
 echo "OPENCODE_AI: '$OPENCODE_AI'"
 echo "CODEX_CLI: '$CODEX_CLI'"
 echo "OR_APP_NAME: '$OR_APP_NAME'"
+echo "GOOSE_TERMINAL: '$GOOSE_TERMINAL'"
 echo "Note: Crush has no environment variables, detected via process tree only"
 
 echo -e "\n=== Environment Detection ==="

--- a/test_priority_order.sh
+++ b/test_priority_order.sh
@@ -36,7 +36,7 @@ fi
 echo ""
 echo -e "${BLUE}=== AI Tool Priority Order Tests ===${NC}"
 echo ""
-echo "Expected priority: Amp > Codex > Claude > Gemini > Qwen > Droid > OpenCode > Cursor > Kimi > Copilot > Zed"
+echo "Expected priority: Amp > Codex > Claude > Gemini > Qwen > Droid > OpenCode > Cursor > Kimi > Copilot > Crush > Goose > Zed"
 echo ""
 
 # Helper function to test detection
@@ -111,10 +111,16 @@ test_detection "Gemini + Qwen" "gemini" "GEMINI_CLI=1" "QWEN_CODE=1"
 # Test 12: Priority order verification - Cursor > Kimi
 test_detection "Cursor + Kimi" "cursor" "CURSOR_AI=1" "KIMI_CLI=1"
 
+# Test 13: Zed + Goose (Goose should win - comes before Zed)
+test_detection "Zed + Goose" "goose" "ZED_TERM=true" "GOOSE_TERMINAL=1"
+
+# Test 14: Priority order verification - Goose > Zed
+test_detection "Goose + Zed" "goose" "GOOSE_TERMINAL=1" "ZED_TERM=true"
+
 echo ""
 echo -e "${GREEN}=== All Priority Order Tests Passed! ===${NC}"
 echo ""
 echo "✓ Zed is correctly prioritized last"
 echo "✓ All higher-priority tools are selected over Zed when present"
-echo "✓ Priority order is correctly enforced: Amp > Codex > Claude > Gemini > Qwen > Droid > OpenCode > Cursor > Kimi > Copilot > Zed"
+echo "✓ Priority order is correctly enforced: Amp > Codex > Claude > Gemini > Qwen > Droid > OpenCode > Cursor > Kimi > Copilot > Crush > Goose > Zed"
 echo ""


### PR DESCRIPTION
## Summary

Implements support for detecting and attributing GitHub CLI operations from [Goose](https://github.com/block/goose), Block's open-source AI coding agent, as requested in #32.

## Changes

- ✅ Added Goose detection via `GOOSE_TERMINAL` environment variable
- ✅ Added Goose detection via process tree (looking for `goose` process)
- ✅ Added Goose to priority order (after Crush, before Zed)
- ✅ Updated README with Goose in supported tools list
- ✅ Updated test files to include Goose detection tests

## Detection Methods

- **Environment Variable**: `GOOSE_TERMINAL=1`
- **Process Name**: `goose`

## Priority Order

Updated priority order: `Amp > Codex > Aider > Claude > Gemini > Qwen > Droid > OpenCode > Cursor > Kimi > Copilot > Crush > Goose > Zed`

Goose is positioned after Crush but before Zed, ensuring proper detection when multiple AI tools are present.

## Testing

Tested by running:
```bash
GOOSE_TERMINAL=1 GH_AI_DEBUG=true ./executable_gh --version
```

The wrapper successfully detects Goose and proceeds with bot token exchange for proper attribution.

## Implementation Details

- **Environment Detection**: Checks for `GOOSE_TERMINAL` environment variable in `check_env_vars()`
- **Process Detection**: Walks process tree looking for `goose` process name in `check_ps_tree()`
- **Priority**: Positioned after Crush but before Zed in the detection priority order
- **Bot Attribution**: When Goose uses `gh` CLI, operations show as `as-a-bot[bot] on behalf of @username`

## Related

This follows the same pattern as implemented in [ai-aligned-git PR #34](https://github.com/trieloff/ai-aligned-git/pull/34).

Fixes #32