### PR TITLE
Add PR template safeguard for agent-driven gh pr create

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,63 @@ gh impersonate --remove someorg/somerepo
 
 This is an explicit opt-in — the wrapper will still fail loudly for repos not in the list, so you always know when attribution is missing.
 
+## 📝 Pull Request Template Safeguard
+
+When an AI tool is detected, the wrapper refuses `gh pr create` (and its `gh pr new` alias) until the agent has explicitly checked whether the target repository defines pull request templates. This nudges agents to discover and use existing PR templates instead of opening PRs with ad-hoc descriptions.
+
+### How the safeguard works
+
+1. The agent runs `gh pr create` for `owner/repo`.
+2. The wrapper looks for a recent "PR template check" cache entry for that repo. If none exists, it exits with code 1 and prints instructions.
+3. The agent runs `gh api repos/<owner>/<repo>/contents/.github/PULL_REQUEST_TEMPLATE` (or `.../PULL_REQUEST_TEMPLATE.md`, or a specific template path inside that directory).
+4. The wrapper observes the call, records a timestamp in `~/.cache/ai-aligned-gh/pr-template-checks/<owner>__<repo>`, and lets the underlying `gh api` request through unchanged.
+5. The next `gh pr create` for the same repo succeeds (up to the cache TTL).
+
+### What counts as a valid check
+
+Any `gh api` call whose endpoint matches one of:
+
+```
+repos/<owner>/<repo>/contents/.github/PULL_REQUEST_TEMPLATE
+repos/<owner>/<repo>/contents/.github/PULL_REQUEST_TEMPLATE/
+repos/<owner>/<repo>/contents/.github/PULL_REQUEST_TEMPLATE.md
+repos/<owner>/<repo>/contents/.github/PULL_REQUEST_TEMPLATE/<file>.md
+```
+
+A leading `/` and a trailing `?ref=...` query string are accepted. A 404 result from GitHub still counts: the agent has done the check, and the wrapper now knows it can let `pr create` through.
+
+### Cache behaviour
+
+- One cache entry per repository at `~/.cache/ai-aligned-gh/pr-template-checks/<owner>__<repo>`.
+- Default TTL is one hour (`PR_TEMPLATE_CACHE_TTL=3600`). Override the TTL by exporting `PR_TEMPLATE_CACHE_TTL` (seconds). Override the location by exporting `PR_TEMPLATE_CACHE_DIR`.
+- The safeguard is bypassed entirely when no AI tool is detected, so human use of `gh pr create` is unaffected.
+
+### Example flow
+
+```bash
+$ CLAUDE_CODE=1 gh pr create --title "Add feature" --body "..."
+
+=================================================================
+  PR Template Check Required
+=================================================================
+
+  AI tool detected: claude
+  Repository: ai-ecoverse/ai-aligned-gh
+
+  Before creating a pull request from an AI agent, you must
+  check whether this repository defines pull request templates.
+  Run:
+
+    gh api repos/ai-ecoverse/ai-aligned-gh/contents/.github/PULL_REQUEST_TEMPLATE
+  ...
+
+$ CLAUDE_CODE=1 gh api repos/ai-ecoverse/ai-aligned-gh/contents/.github/PULL_REQUEST_TEMPLATE
+# (response shows templates or 404 — either way the check is recorded)
+
+$ CLAUDE_CODE=1 gh pr create --title "Add feature" --body "..."
+# proceeds normally for the next hour
+```
+
 ## 🤖 Supported AI Tools
 
 The wrapper automatically detects:
@@ -177,6 +234,8 @@ The wrapper automatically detects:
 | `GH_AI_DEBUG` | Enable debug output | `false` |
 | `AS_A_BOT_URL` | as-a-bot service URL | `https://as-bot-worker.minivelos.workers.dev` |
 | `GH_TOKEN` | GitHub token override | (uses `gh auth token`) |
+| `PR_TEMPLATE_CACHE_TTL` | PR template check cache lifetime (seconds) | `3600` |
+| `PR_TEMPLATE_CACHE_DIR` | PR template check cache directory | `~/.cache/ai-aligned-gh/pr-template-checks` |
 
 ### PATH Configuration
 

--- a/executable_gh
+++ b/executable_gh
@@ -552,6 +552,130 @@ check_ps_tree() { ami_check_ps_tree; }
 detect_ai_tool() { ami_detect; }
 # --- END BUNDLED am-i-ai ---
 
+# --- BEGIN PR template safeguard ---
+# When an AI tool is in control and creates a pull request, ensure the agent
+# has first verified whether the repository has PR templates. We require a
+# `gh api repos/<owner>/<repo>/contents/.github/PULL_REQUEST_TEMPLATE[.md]`
+# call to have been observed by this wrapper within the last hour for the
+# target repo. The result of the check is cached per repository so that
+# repeat pr-create calls within the window do not require re-checking.
+
+PR_TEMPLATE_CACHE_DIR="${PR_TEMPLATE_CACHE_DIR:-$HOME/.cache/ai-aligned-gh/pr-template-checks}"
+PR_TEMPLATE_CACHE_TTL="${PR_TEMPLATE_CACHE_TTL:-3600}"
+
+pr_template_cache_file() {
+    local owner="$1"
+    local repo="$2"
+    # Sanitize: keep alnum, dot, dash, underscore. Use printf to avoid the
+    # trailing newline that `echo` would emit (which tr -c would also rewrite).
+    local safe_owner safe_repo
+    safe_owner=$(printf '%s' "$owner" | tr -c 'A-Za-z0-9._-' '_')
+    safe_repo=$(printf '%s' "$repo" | tr -c 'A-Za-z0-9._-' '_')
+    echo "$PR_TEMPLATE_CACHE_DIR/${safe_owner}__${safe_repo}"
+}
+
+pr_template_check_is_fresh() {
+    local owner="$1"
+    local repo="$2"
+    local cache_file
+    cache_file=$(pr_template_cache_file "$owner" "$repo")
+
+    if [ ! -f "$cache_file" ]; then
+        return 1
+    fi
+
+    local mtime
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        mtime=$(stat -f %m "$cache_file" 2>/dev/null)
+    else
+        mtime=$(stat -c %Y "$cache_file" 2>/dev/null)
+    fi
+
+    if [ -z "$mtime" ]; then
+        return 1
+    fi
+
+    local now age
+    now=$(date +%s)
+    age=$((now - mtime))
+
+    if [ "$age" -lt "$PR_TEMPLATE_CACHE_TTL" ]; then
+        return 0
+    fi
+    return 1
+}
+
+record_pr_template_check() {
+    local owner="$1"
+    local repo="$2"
+    local cache_file
+    cache_file=$(pr_template_cache_file "$owner" "$repo")
+    mkdir -p "$PR_TEMPLATE_CACHE_DIR"
+    : > "$cache_file"
+}
+
+# Inspect args for a `gh api` invocation and detect whether the endpoint
+# targets the PR template directory or file. Echoes "<owner> <repo>" and
+# returns 0 on match, 1 otherwise. Expects the full args list including
+# the leading "api" subcommand.
+extract_pr_template_repo_from_api_args() {
+    local args=("$@")
+    local n=${#args[@]}
+    local i=1  # skip "api"
+    while [ $i -lt $n ]; do
+        local arg="${args[$i]}"
+        if [[ "$arg" =~ ^/?repos/([^/]+)/([^/]+)/contents/\.github/PULL_REQUEST_TEMPLATE(\.md)?/?$ ]] \
+           || [[ "$arg" =~ ^/?repos/([^/]+)/([^/]+)/contents/\.github/PULL_REQUEST_TEMPLATE/ ]]; then
+            echo "${BASH_REMATCH[1]} ${BASH_REMATCH[2]}"
+            return 0
+        fi
+        i=$((i + 1))
+    done
+    return 1
+}
+
+# Detect whether the args list represents `gh pr create` (the first
+# positional arg after global flags is "pr" followed by "create"). We
+# accept some leading global flags such as --repo/-R and --hostname.
+is_pr_create_invocation() {
+    local args=("$@")
+    local n=${#args[@]}
+    local i=0
+    local found_pr=false
+    while [ $i -lt $n ]; do
+        local arg="${args[$i]}"
+        case "$arg" in
+            --repo|-R|--hostname)
+                i=$((i + 2)); continue ;;
+            --repo=*|--hostname=*)
+                i=$((i + 1)); continue ;;
+            -*)
+                # Unknown global flag — skip just this token to be safe.
+                i=$((i + 1)); continue ;;
+            pr)
+                found_pr=true
+                i=$((i + 1))
+                break ;;
+            *)
+                return 1 ;;
+        esac
+    done
+    if ! $found_pr; then
+        return 1
+    fi
+    # Now look for "create" as the next positional, skipping leading flags.
+    while [ $i -lt $n ]; do
+        local arg="${args[$i]}"
+        case "$arg" in
+            -*) i=$((i + 1)); continue ;;
+            create) return 0 ;;
+            *) return 1 ;;
+        esac
+    done
+    return 1
+}
+# --- END PR template safeguard ---
+
 # Function to find the real gh executable
 find_real_gh() {
     # Common locations for gh
@@ -1265,6 +1389,55 @@ fi
 # AI detected - show info if in debug mode
 if [ "$DEBUG" = "true" ]; then
     echo "[INFO] AI detected: $AI_TOOL - checking for bot token exchange..." >&2
+fi
+
+# PR template safeguard: record check when agent inspects PR template path
+if [ "$1" = "api" ]; then
+    if read -r _ptl_owner _ptl_repo < <(extract_pr_template_repo_from_api_args "$@"); then
+        if [ -n "$_ptl_owner" ] && [ -n "$_ptl_repo" ]; then
+            record_pr_template_check "$_ptl_owner" "$_ptl_repo"
+            debug_log "Recorded PR template check for $_ptl_owner/$_ptl_repo"
+        fi
+    fi
+fi
+
+# PR template safeguard: block `gh pr create` until the agent has verified
+# whether the target repo has pull request templates. The check is cached
+# per repository for $PR_TEMPLATE_CACHE_TTL seconds (default: 1 hour).
+if is_pr_create_invocation "$@"; then
+    _ptc_repo_spec=""
+    _ptc_repo_spec=$(parse_repo_flag "$@") || _ptc_repo_spec=""
+    if read -r _ptc_owner _ptc_repo < <(get_repo_info "$_ptc_repo_spec"); then
+        if [ -n "$_ptc_owner" ] && [ -n "$_ptc_repo" ]; then
+            if ! pr_template_check_is_fresh "$_ptc_owner" "$_ptc_repo"; then
+                echo "" >&2
+                echo "=================================================================" >&2
+                echo "  PR Template Check Required" >&2
+                echo "=================================================================" >&2
+                echo "" >&2
+                echo "  AI tool detected: $AI_TOOL" >&2
+                echo "  Repository: $_ptc_owner/$_ptc_repo" >&2
+                echo "" >&2
+                echo "  Before creating a pull request from an AI agent, you must" >&2
+                echo "  check whether this repository defines pull request templates." >&2
+                echo "  Run:" >&2
+                echo "" >&2
+                echo "    gh api repos/$_ptc_owner/$_ptc_repo/contents/.github/PULL_REQUEST_TEMPLATE" >&2
+                echo "" >&2
+                echo "  If the directory exists, use one of the listed templates with" >&2
+                echo "  the --template flag when creating the PR. If it returns 404," >&2
+                echo "  also check for a single-file template:" >&2
+                echo "" >&2
+                echo "    gh api repos/$_ptc_owner/$_ptc_repo/contents/.github/PULL_REQUEST_TEMPLATE.md" >&2
+                echo "" >&2
+                echo "  After running either command, retry your pr create. This check" >&2
+                echo "  is cached per repository for $((PR_TEMPLATE_CACHE_TTL / 60)) minutes." >&2
+                echo "" >&2
+                exit 1
+            fi
+            debug_log "PR template check is fresh for $_ptc_owner/$_ptc_repo, allowing pr create"
+        fi
+    fi
 fi
 
 # Check if this is a safe operation that doesn't need token exchange

--- a/executable_gh
+++ b/executable_gh
@@ -615,17 +615,25 @@ record_pr_template_check() {
 }
 
 # Inspect args for a `gh api` invocation and detect whether the endpoint
-# targets the PR template directory or file. Echoes "<owner> <repo>" and
-# returns 0 on match, 1 otherwise. Expects the full args list including
-# the leading "api" subcommand.
+# targets the PR template directory or file. Accepts:
+#   repos/<o>/<r>/contents/.github/PULL_REQUEST_TEMPLATE
+#   repos/<o>/<r>/contents/.github/PULL_REQUEST_TEMPLATE/
+#   repos/<o>/<r>/contents/.github/PULL_REQUEST_TEMPLATE.md
+#   repos/<o>/<r>/contents/.github/PULL_REQUEST_TEMPLATE/<file>.md
+# All of the above may carry an optional ?query string (e.g. ?ref=main).
+# Echoes "<owner> <repo>" and returns 0 on match, 1 otherwise. Expects the
+# full args list including the leading "api" subcommand.
 extract_pr_template_repo_from_api_args() {
     local args=("$@")
     local n=${#args[@]}
     local i=1  # skip "api"
     while [ $i -lt $n ]; do
         local arg="${args[$i]}"
-        if [[ "$arg" =~ ^/?repos/([^/]+)/([^/]+)/contents/\.github/PULL_REQUEST_TEMPLATE(\.md)?/?$ ]] \
-           || [[ "$arg" =~ ^/?repos/([^/]+)/([^/]+)/contents/\.github/PULL_REQUEST_TEMPLATE/ ]]; then
+        # Strip any leading "/" and trailing "?query" to simplify matching.
+        local endpoint="${arg#/}"
+        endpoint="${endpoint%%\?*}"
+        if [[ "$endpoint" =~ ^repos/([^/]+)/([^/]+)/contents/\.github/PULL_REQUEST_TEMPLATE(\.md)?/?$ ]] \
+           || [[ "$endpoint" =~ ^repos/([^/]+)/([^/]+)/contents/\.github/PULL_REQUEST_TEMPLATE/[^/]+ ]]; then
             echo "${BASH_REMATCH[1]} ${BASH_REMATCH[2]}"
             return 0
         fi
@@ -634,24 +642,49 @@ extract_pr_template_repo_from_api_args() {
     return 1
 }
 
-# Detect whether the args list represents `gh pr create` (the first
-# positional arg after global flags is "pr" followed by "create"). We
-# accept some leading global flags such as --repo/-R and --hostname.
+# Helper: return 0 if the given flag is known to take a value (so the next
+# token should also be skipped during subcommand resolution). Covers the
+# gh global flags (--hostname, --config) and the inherited / common flags
+# used by `gh pr create`/`gh pr new`. False positives here are harmless;
+# false negatives can let `pr create` slip past the safeguard.
+_gh_flag_takes_value() {
+    case "$1" in
+        --repo|-R|--hostname|--config| \
+        --base|-B|--head|-H| \
+        --title|-t|--body|-b|--body-file|-F| \
+        --label|-l|--assignee|-a|--milestone|-m|--project|-p| \
+        --reviewer|-r|--template|-T| \
+        --editor)
+            return 0 ;;
+    esac
+    return 1
+}
+
+# Detect whether the args list represents `gh pr create` (or its alias
+# `gh pr new`). Tolerates global flags before `pr`, inherited flags
+# between `pr` and the subcommand (notably `-R/--repo owner/repo`), and
+# both the `--flag value` and `--flag=value` forms. Returns 0 if the
+# invocation creates a pull request.
 is_pr_create_invocation() {
     local args=("$@")
     local n=${#args[@]}
     local i=0
     local found_pr=false
+
+    # Phase 1: locate the "pr" command, skipping any global flags.
     while [ $i -lt $n ]; do
         local arg="${args[$i]}"
         case "$arg" in
-            --repo|-R|--hostname)
-                i=$((i + 2)); continue ;;
-            --repo=*|--hostname=*)
+            --*=*|-[A-Za-z0-9]=*)
+                # Combined --flag=value or -X=value: skip just this token.
                 i=$((i + 1)); continue ;;
             -*)
-                # Unknown global flag — skip just this token to be safe.
-                i=$((i + 1)); continue ;;
+                if _gh_flag_takes_value "$arg"; then
+                    i=$((i + 2))
+                else
+                    i=$((i + 1))
+                fi
+                continue ;;
             pr)
                 found_pr=true
                 i=$((i + 1))
@@ -663,13 +696,25 @@ is_pr_create_invocation() {
     if ! $found_pr; then
         return 1
     fi
-    # Now look for "create" as the next positional, skipping leading flags.
+
+    # Phase 2: find the next positional subcommand, skipping inherited /
+    # subcommand-level flags (e.g. `pr -R o/r create`).
     while [ $i -lt $n ]; do
         local arg="${args[$i]}"
         case "$arg" in
-            -*) i=$((i + 1)); continue ;;
-            create) return 0 ;;
-            *) return 1 ;;
+            --*=*|-[A-Za-z0-9]=*)
+                i=$((i + 1)); continue ;;
+            -*)
+                if _gh_flag_takes_value "$arg"; then
+                    i=$((i + 2))
+                else
+                    i=$((i + 1))
+                fi
+                continue ;;
+            create|new)
+                return 0 ;;
+            *)
+                return 1 ;;
         esac
     done
     return 1

--- a/test_pr_template_integration.sh
+++ b/test_pr_template_integration.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+
+# Integration test for the PR template safeguard. Uses a fake `gh` binary
+# to avoid real network calls and isolates HOME / cache.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WRAPPER="$SCRIPT_DIR/executable_gh"
+
+PASS=0
+FAIL=0
+
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+# Build an isolated environment.
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+FAKE_BIN="$TMP_DIR/bin"
+mkdir -p "$FAKE_BIN"
+
+# Fake gh: handles the calls our wrapper makes, prints stable JSON, and
+# exits 0. Anything else is a no-op success.
+cat > "$FAKE_BIN/gh" <<'EOF'
+#!/bin/bash
+if [ "$1" = "repo" ] && [ "$2" = "view" ]; then
+    # gh repo view --json nameWithOwner --jq '.nameWithOwner'
+    echo "fakeowner/fakerepo"
+    exit 0
+fi
+if [ "$1" = "api" ]; then
+    # Accept any API call silently
+    echo '{}'
+    exit 0
+fi
+# Pretend any other command succeeded.
+exit 0
+EOF
+chmod +x "$FAKE_BIN/gh"
+
+# Set up isolated HOME so cache writes happen in TMP_DIR.
+ISOLATED_HOME="$TMP_DIR/home"
+mkdir -p "$ISOLATED_HOME"
+
+run_wrapper() {
+    # Place fake gh first in PATH so find_real_gh picks it up. Mark Droid
+    # as the active AI tool so the safeguard is triggered.
+    env -i \
+        HOME="$ISOLATED_HOME" \
+        PATH="$FAKE_BIN:/usr/bin:/bin" \
+        DROID_CLI=1 \
+        bash "$WRAPPER" "$@"
+}
+
+cache_file_for() {
+    echo "$ISOLATED_HOME/.cache/ai-aligned-gh/pr-template-checks/${1}__${2}"
+}
+
+REPO_FLAG_OWNER="fakeowner"
+REPO_FLAG_REPO="fakerepo"
+REPO_SPEC="${REPO_FLAG_OWNER}/${REPO_FLAG_REPO}"
+
+echo "=== Integration: gh pr create rejected before template check ==="
+output=$(run_wrapper --repo "$REPO_SPEC" pr create --title hi --body world 2>&1)
+rc=$?
+if [ "$rc" -ne 0 ] && echo "$output" | grep -q "PR Template Check Required"; then
+    pass "pr create rejected with safeguard message"
+else
+    fail "expected rejection, got rc=$rc, output: $output"
+fi
+
+echo ""
+echo "=== Integration: gh api PULL_REQUEST_TEMPLATE records cache ==="
+run_wrapper api "repos/${REPO_FLAG_OWNER}/${REPO_FLAG_REPO}/contents/.github/PULL_REQUEST_TEMPLATE" >/dev/null 2>&1 || true
+cache_path=$(cache_file_for "$REPO_FLAG_OWNER" "$REPO_FLAG_REPO")
+if [ -f "$cache_path" ]; then
+    pass "cache file created after gh api call"
+else
+    fail "expected cache file at $cache_path"
+fi
+
+echo ""
+echo "=== Integration: gh pr create allowed after recent check ==="
+output=$(run_wrapper --repo "$REPO_SPEC" pr create --title hi --body world 2>&1)
+if echo "$output" | grep -q "PR Template Check Required"; then
+    fail "pr create still rejected after template check was recorded: $output"
+else
+    pass "pr create not blocked by safeguard after recent check"
+fi
+
+echo ""
+echo "=== Integration: per-repo isolation via --repo flag ==="
+output=$(run_wrapper --repo other/proj pr create --title T --body B 2>&1)
+rc=$?
+if [ "$rc" -ne 0 ] && echo "$output" | grep -q "other/proj"; then
+    pass "--repo flag drives safeguard message for different repo"
+else
+    fail "expected rejection mentioning other/proj, rc=$rc, output: $output"
+fi
+
+# Record check for that repo via .md variant.
+run_wrapper api "repos/other/proj/contents/.github/PULL_REQUEST_TEMPLATE.md" >/dev/null 2>&1 || true
+output=$(run_wrapper --repo other/proj pr create --title T --body B 2>&1)
+if echo "$output" | grep -q "PR Template Check Required"; then
+    fail "pr create still rejected after .md endpoint check"
+else
+    pass ".md endpoint counts as PR template check"
+fi
+
+echo ""
+echo "=== Integration: no AI detected bypasses safeguard ==="
+# AMI_PASSTHROUGH=true forces am-i-ai to report "none" regardless of the
+# surrounding process tree, so we can verify the safeguard is bypassed.
+output=$(env -i HOME="$ISOLATED_HOME" PATH="$FAKE_BIN:/usr/bin:/bin" \
+    AMI_PASSTHROUGH=true \
+    bash "$WRAPPER" --repo othernoai/nope pr create --title hi --body world 2>&1 || true)
+if echo "$output" | grep -q "PR Template Check Required"; then
+    fail "safeguard fired even without AI detected: $output"
+else
+    pass "no AI detected: safeguard bypassed"
+fi
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -gt 0 ] && exit 1
+exit 0

--- a/test_pr_template_safeguard.sh
+++ b/test_pr_template_safeguard.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+
+# Test PR template safeguard helpers from executable_gh.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+EXECUTABLE_GH="$SCRIPT_DIR/executable_gh"
+
+# Pull in the helper functions without executing the main script.
+extract_block() {
+    local name="$1"
+    sed -n "/^${name}()/,/^}/p" "$EXECUTABLE_GH"
+}
+
+eval "$(extract_block pr_template_cache_file)"
+eval "$(extract_block pr_template_check_is_fresh)"
+eval "$(extract_block record_pr_template_check)"
+eval "$(extract_block extract_pr_template_repo_from_api_args)"
+eval "$(extract_block is_pr_create_invocation)"
+
+# Use an isolated cache dir for the tests.
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+PR_TEMPLATE_CACHE_DIR="$TMP_DIR/cache"
+PR_TEMPLATE_CACHE_TTL=3600
+export PR_TEMPLATE_CACHE_DIR PR_TEMPLATE_CACHE_TTL
+
+PASS=0
+FAIL=0
+
+pass() {
+    echo "PASS: $1"
+    PASS=$((PASS + 1))
+}
+
+fail() {
+    echo "FAIL: $1"
+    FAIL=$((FAIL + 1))
+}
+
+assert_pr_create() {
+    local desc="$1"; shift
+    if is_pr_create_invocation "$@"; then
+        pass "$desc (recognized as pr create)"
+    else
+        fail "$desc — expected pr create, was not recognized"
+    fi
+}
+
+assert_not_pr_create() {
+    local desc="$1"; shift
+    if is_pr_create_invocation "$@"; then
+        fail "$desc — incorrectly recognized as pr create"
+    else
+        pass "$desc (not pr create)"
+    fi
+}
+
+assert_api_match() {
+    local desc="$1"
+    local expected_owner="$2"
+    local expected_repo="$3"
+    shift 3
+    local got_owner got_repo
+    if read -r got_owner got_repo < <(extract_pr_template_repo_from_api_args "$@"); then
+        if [ "$got_owner" = "$expected_owner" ] && [ "$got_repo" = "$expected_repo" ]; then
+            pass "$desc → $got_owner/$got_repo"
+        else
+            fail "$desc → got $got_owner/$got_repo, expected $expected_owner/$expected_repo"
+        fi
+    else
+        fail "$desc → did not match (expected $expected_owner/$expected_repo)"
+    fi
+}
+
+assert_api_nomatch() {
+    local desc="$1"; shift
+    if extract_pr_template_repo_from_api_args "$@" >/dev/null; then
+        fail "$desc — unexpectedly matched"
+    else
+        pass "$desc (no match)"
+    fi
+}
+
+echo "=== is_pr_create_invocation() ==="
+assert_pr_create     "pr create"                               pr create
+assert_pr_create     "pr create --title T --body B"            pr create --title T --body B
+assert_pr_create     "--repo o/r pr create"                    --repo o/r pr create
+assert_pr_create     "-R o/r pr create --fill"                 -R o/r pr create --fill
+assert_pr_create     "pr --some-flag create"                   pr --some-flag create
+assert_not_pr_create "pr list"                                 pr list
+assert_not_pr_create "pr view 123"                             pr view 123
+assert_not_pr_create "pr edit 1"                               pr edit 1
+assert_not_pr_create "issue create"                            issue create
+assert_not_pr_create "api repos/o/r/pulls"                     api repos/o/r/pulls
+assert_not_pr_create "repo create new-repo"                    repo create new-repo
+
+echo ""
+echo "=== extract_pr_template_repo_from_api_args() ==="
+assert_api_match    "directory endpoint"                   o   r       api repos/o/r/contents/.github/PULL_REQUEST_TEMPLATE
+assert_api_match    "directory endpoint trailing slash"    o   r       api repos/o/r/contents/.github/PULL_REQUEST_TEMPLATE/
+assert_api_match    "single file .md endpoint"             a   b       api repos/a/b/contents/.github/PULL_REQUEST_TEMPLATE.md
+assert_api_match    "specific template inside dir"         x   y       api repos/x/y/contents/.github/PULL_REQUEST_TEMPLATE/feature.md
+assert_api_match    "leading slash endpoint"               ai  gh-wrap api /repos/ai/gh-wrap/contents/.github/PULL_REQUEST_TEMPLATE
+assert_api_match    "endpoint after flags"                 o   r       api --jq .name repos/o/r/contents/.github/PULL_REQUEST_TEMPLATE
+assert_api_nomatch  "unrelated repos endpoint"                         api repos/o/r/pulls
+assert_api_nomatch  "issue template path"                              api repos/o/r/contents/.github/ISSUE_TEMPLATE
+assert_api_nomatch  "graphql endpoint"                                 api graphql
+assert_api_nomatch  "non-api command"                                  pr list
+
+echo ""
+echo "=== cache freshness ==="
+mkdir -p "$PR_TEMPLATE_CACHE_DIR"
+
+if pr_template_check_is_fresh "newowner" "newrepo"; then
+    fail "fresh check on missing cache should fail"
+else
+    pass "missing cache reports not fresh"
+fi
+
+record_pr_template_check "owner1" "repo1"
+if pr_template_check_is_fresh "owner1" "repo1"; then
+    pass "freshly recorded check is fresh"
+else
+    fail "freshly recorded check should be fresh"
+fi
+
+# Per-repo isolation: recording for owner1/repo1 must not satisfy owner2/repo2
+if pr_template_check_is_fresh "owner2" "repo2"; then
+    fail "cache leaked across repos"
+else
+    pass "per-repo cache isolation"
+fi
+
+# Force stale by backdating mtime beyond TTL
+cache_file=$(pr_template_cache_file "owner1" "repo1")
+if [ -f "$cache_file" ]; then
+    # Set mtime to 2 hours ago
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        touch -t "$(date -v-2H +%Y%m%d%H%M.%S)" "$cache_file"
+    else
+        touch -d "2 hours ago" "$cache_file"
+    fi
+    if pr_template_check_is_fresh "owner1" "repo1"; then
+        fail "stale cache should not be fresh"
+    else
+        pass "stale cache correctly expired"
+    fi
+fi
+
+# Custom TTL: 0 means everything is stale
+(
+    PR_TEMPLATE_CACHE_TTL=0
+    record_pr_template_check "ttlowner" "ttlrepo"
+    if pr_template_check_is_fresh "ttlowner" "ttlrepo"; then
+        fail "TTL=0 should treat freshly written cache as stale"
+        exit 1
+    else
+        pass "TTL=0 honored"
+    fi
+)
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/test_pr_template_safeguard.sh
+++ b/test_pr_template_safeguard.sh
@@ -17,6 +17,7 @@ eval "$(extract_block pr_template_cache_file)"
 eval "$(extract_block pr_template_check_is_fresh)"
 eval "$(extract_block record_pr_template_check)"
 eval "$(extract_block extract_pr_template_repo_from_api_args)"
+eval "$(extract_block _gh_flag_takes_value)"
 eval "$(extract_block is_pr_create_invocation)"
 
 # Use an isolated cache dir for the tests.
@@ -85,16 +86,27 @@ assert_api_nomatch() {
 
 echo "=== is_pr_create_invocation() ==="
 assert_pr_create     "pr create"                               pr create
+assert_pr_create     "pr new (alias)"                          pr new
+assert_pr_create     "pr new --title T --body B"               pr new --title T --body B
 assert_pr_create     "pr create --title T --body B"            pr create --title T --body B
 assert_pr_create     "--repo o/r pr create"                    --repo o/r pr create
 assert_pr_create     "-R o/r pr create --fill"                 -R o/r pr create --fill
+assert_pr_create     "--repo=o/r pr create"                    --repo=o/r pr create
+assert_pr_create     "pr -R o/r create"                        pr -R o/r create
+assert_pr_create     "pr --repo o/r create"                    pr --repo o/r create
+assert_pr_create     "pr --repo=o/r create"                    pr --repo=o/r create
+assert_pr_create     "pr -R o/r new"                           pr -R o/r new
+assert_pr_create     "--config /tmp/cfg pr create"             --config /tmp/cfg pr create
+assert_pr_create     "--hostname gh.example pr create"         --hostname gh.example pr create
 assert_pr_create     "pr --some-flag create"                   pr --some-flag create
 assert_not_pr_create "pr list"                                 pr list
 assert_not_pr_create "pr view 123"                             pr view 123
 assert_not_pr_create "pr edit 1"                               pr edit 1
+assert_not_pr_create "pr review --approve"                     pr review --approve
 assert_not_pr_create "issue create"                            issue create
 assert_not_pr_create "api repos/o/r/pulls"                     api repos/o/r/pulls
 assert_not_pr_create "repo create new-repo"                    repo create new-repo
+assert_not_pr_create "pr -R o/r list"                          pr -R o/r list
 
 echo ""
 echo "=== extract_pr_template_repo_from_api_args() ==="
@@ -104,10 +116,15 @@ assert_api_match    "single file .md endpoint"             a   b       api repos
 assert_api_match    "specific template inside dir"         x   y       api repos/x/y/contents/.github/PULL_REQUEST_TEMPLATE/feature.md
 assert_api_match    "leading slash endpoint"               ai  gh-wrap api /repos/ai/gh-wrap/contents/.github/PULL_REQUEST_TEMPLATE
 assert_api_match    "endpoint after flags"                 o   r       api --jq .name repos/o/r/contents/.github/PULL_REQUEST_TEMPLATE
+assert_api_match    "endpoint with ?ref=main"              o   r       api "repos/o/r/contents/.github/PULL_REQUEST_TEMPLATE?ref=main"
+assert_api_match    "endpoint .md with ?ref=main"          a   b       api "repos/a/b/contents/.github/PULL_REQUEST_TEMPLATE.md?ref=main"
+assert_api_match    "endpoint dir trailing slash + query"  o   r       api "repos/o/r/contents/.github/PULL_REQUEST_TEMPLATE/?ref=feature"
+assert_api_match    "specific file with query"             x   y       api "repos/x/y/contents/.github/PULL_REQUEST_TEMPLATE/bug.md?ref=main"
 assert_api_nomatch  "unrelated repos endpoint"                         api repos/o/r/pulls
 assert_api_nomatch  "issue template path"                              api repos/o/r/contents/.github/ISSUE_TEMPLATE
 assert_api_nomatch  "graphql endpoint"                                 api graphql
 assert_api_nomatch  "non-api command"                                  pr list
+assert_api_nomatch  "look-alike with suffix"                           api repos/o/r/contents/.github/PULL_REQUEST_TEMPLATE_legacy
 
 echo ""
 echo "=== cache freshness ==="


### PR DESCRIPTION
## Summary

When an AI tool is in control and tries to run `gh pr create`, this safeguard rejects the call until the agent has explicitly checked whether the target repository has pull request templates. The check is satisfied by any `gh api repos/<owner>/<repo>/contents/.github/PULL_REQUEST_TEMPLATE[.md]` (directory, single-file, or per-template path), and the result is cached per repository for one hour so repeat PR creations within the window don't have to re-check.

## Behavior

- Trigger: an AI tool is detected (`am-i-ai` => non-"none") **and** the command resolves to `gh pr create`.
- Owner/repo is resolved from `--repo`/`-R` if given, otherwise from `gh repo view` in the cwd.
- If no fresh cache entry exists, the wrapper exits with code 1 and prints a message instructing the agent to run the PR-template `gh api` call.
- When the wrapper observes a matching `gh api .../PULL_REQUEST_TEMPLATE[.md|/<file>.md]` call, it records a timestamp for that repo.
- TTL is configurable via the `PR_TEMPLATE_CACHE_TTL` env var (default 3600 seconds). Cache dir is `~/.cache/ai-aligned-gh/pr-template-checks/<owner>__<repo>`.
- No AI detected => safeguard is bypassed entirely (the existing passthrough is preserved).

## Tests

- `test_pr_template_safeguard.sh` -- unit tests for `is_pr_create_invocation`, `extract_pr_template_repo_from_api_args`, cache freshness + per-repo isolation + TTL handling (25 assertions).
- `test_pr_template_integration.sh` -- end-to-end exercise of the wrapper with a fake `gh`, isolated `HOME`, and `AMI_PASSTHROUGH` to confirm the rejection message, the cache write on `gh api`, and the no-AI passthrough (6 assertions).
- Existing `test_safe_operation.sh` and `test_impersonate.sh` still pass.

## Notes

The wrapper deliberately does **not** silently perform the check itself -- the spec calls for the agent to learn that the check is required, so the safeguard rejects the first attempt with explicit instructions before allowing PR creation.