### PR TITLE
Return as-a-bot token for `gh auth token` under AI detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,20 @@ When an AI is detected and performing a write operation:
 
 Read-only operations (like `gh pr list`) skip token exchange for performance.
 
+### `gh auth token` returns the bot token
+
+When an AI tool runs `gh auth token`, the wrapper returns the **as-a-bot
+user-to-server token**, not your personal token. This closes the most common
+way agents bypass attribution: capturing the personal token from `gh auth
+token` and calling the GitHub API directly (e.g. `curl -H "Authorization: token
+<token>"`), which would record actions as you instead of as `as-a-bot[bot]`.
+Because the bot token is what comes back, that path now stays attributed.
+
+Humans are unaffected — when no AI tool is detected, `gh auth token` passes
+through to the real `gh` and returns your personal token as usual. If the bot
+token cannot be issued (app not yet authorized), the command fails closed rather
+than falling back to your personal token.
+
 ## 📋 Prerequisites
 
 1. **GitHub CLI**: Install from [cli.github.com](https://cli.github.com/)
@@ -236,6 +250,7 @@ The wrapper automatically detects:
 | `GH_TOKEN` | GitHub token override | (uses `gh auth token`) |
 | `PR_TEMPLATE_CACHE_TTL` | PR template check cache lifetime (seconds) | `3600` |
 | `PR_TEMPLATE_CACHE_DIR` | PR template check cache directory | `~/.cache/ai-aligned-gh/pr-template-checks` |
+| `AI_ALIGNED_GH_BIN` | Override path to the real `gh` (testing hook; unset in normal use) | (auto-detected) |
 
 ### PATH Configuration
 

--- a/executable_gh
+++ b/executable_gh
@@ -1461,6 +1461,15 @@ fi
 # attributed to the bot. (Non-AI callers never reach this block — they passed
 # through to the real gh above and get their personal token unchanged.)
 if [ "$1" = "auth" ] && [ "$2" = "token" ]; then
+    # Help requests don't expose a token — pass them straight through so
+    # `gh auth token --help` / `-h` still prints usage instead of a token.
+    for _arg in "$@"; do
+        case "$_arg" in
+            -h|--help)
+                exec "$GH_BIN" "$@"
+                ;;
+        esac
+    done
     debug_log "auth token requested by AI tool ($AI_TOOL) - issuing as-a-bot token, not personal token"
     BOT_TOKEN=$(get_cached_token)
     if [ -n "$BOT_TOKEN" ]; then

--- a/executable_gh
+++ b/executable_gh
@@ -723,6 +723,14 @@ is_pr_create_invocation() {
 
 # Function to find the real gh executable
 find_real_gh() {
+    # Test/override hook: AI_ALIGNED_GH_BIN points at the real gh explicitly.
+    # Unset in normal use, so production behavior is unchanged; tests use it to
+    # substitute a fake gh without depending on the host's installation.
+    if [ -n "${AI_ALIGNED_GH_BIN:-}" ] && [ -x "${AI_ALIGNED_GH_BIN}" ]; then
+        echo "$AI_ALIGNED_GH_BIN"
+        return
+    fi
+
     # Common locations for gh
     local gh_paths=(
         "/usr/bin/gh"
@@ -797,7 +805,11 @@ is_safe_operation() {
             ;;
         auth)
             case "$subcommand" in
-                status|login|logout|refresh|setup-git|token)
+                # `token` is intentionally NOT listed here. Under AI detection it
+                # is intercepted earlier and returns the as-a-bot token; treating
+                # it as "safe" would let it pass through to the real gh and leak
+                # the user's personal token.
+                status|login|logout|refresh|setup-git)
                     return 0
                     ;;
             esac
@@ -1434,6 +1446,33 @@ fi
 # AI detected - show info if in debug mode
 if [ "$DEBUG" = "true" ]; then
     echo "[INFO] AI detected: $AI_TOOL - checking for bot token exchange..." >&2
+fi
+
+# Token guard: when an AI tool runs `gh auth token`, return the as-a-bot
+# user-to-server token instead of the user's personal token.
+#
+# `gh auth token` prints a token to stdout. The default `gh` would print the
+# user's personal OAuth token, and an agent that captures it can call the
+# GitHub API directly (e.g. curl with `Authorization: token <token>`),
+# bypassing this wrapper entirely — so the actions get recorded as the human
+# rather than as as-a-bot[bot] acting on their behalf. This is the single most
+# common circumvention path. By handing back the as-a-bot token here, that
+# bypass becomes harmless: anything the agent does with this token is still
+# attributed to the bot. (Non-AI callers never reach this block — they passed
+# through to the real gh above and get their personal token unchanged.)
+if [ "$1" = "auth" ] && [ "$2" = "token" ]; then
+    debug_log "auth token requested by AI tool ($AI_TOOL) - issuing as-a-bot token, not personal token"
+    BOT_TOKEN=$(get_cached_token)
+    if [ -n "$BOT_TOKEN" ]; then
+        echo "$BOT_TOKEN"
+        exit 0
+    fi
+    # No bot token available yet. get_cached_token has already emitted device-flow
+    # authorization instructions to stderr. Fail closed rather than fall back to
+    # the personal token.
+    echo "[ERROR] as-a-bot authentication required before a token can be issued." >&2
+    echo "        Authorize the app (see instructions above), then try again." >&2
+    exit 1
 fi
 
 # PR template safeguard: record check when agent inspects PR template path

--- a/test_auth_token_attribution.sh
+++ b/test_auth_token_attribution.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+
+# Integration test for the `gh auth token` attribution guard.
+#
+# Under AI detection the wrapper must return the as-a-bot user-to-server token,
+# never the user's personal token — otherwise an agent can capture the personal
+# token and call the GitHub API directly, bypassing attribution. A non-AI caller
+# must still get their personal token unchanged.
+#
+# Uses a fake gh (via AI_ALIGNED_GH_BIN) and an isolated HOME so there are no
+# real network calls or shared cache.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WRAPPER="$SCRIPT_DIR/executable_gh"
+
+PASS=0
+FAIL=0
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+FAKE_BIN="$TMP_DIR/bin"
+mkdir -p "$FAKE_BIN"
+
+# Sentinels let us prove which token came back.
+BOT_TOKEN="ghu_BOT_TOKEN_SENTINEL"
+PERSONAL_TOKEN="ghp_PERSONAL_TOKEN_SENTINEL"
+
+# Fake gh: validates any token (api user -> ok) and, for `auth token`, prints
+# the PERSONAL token — exactly what the real gh would leak. If the guard works,
+# this string must never reach stdout under AI detection.
+cat > "$FAKE_BIN/gh" <<EOF
+#!/bin/bash
+if [ "\$1" = "auth" ] && [ "\$2" = "token" ]; then
+    echo "$PERSONAL_TOKEN"
+    exit 0
+fi
+if [ "\$1" = "api" ]; then
+    echo '{}'
+    exit 0
+fi
+exit 0
+EOF
+chmod +x "$FAKE_BIN/gh"
+
+ISOLATED_HOME="$TMP_DIR/home"
+mkdir -p "$ISOLATED_HOME/.cache/ai-aligned-gh"
+
+seed_bot_token() {
+    printf '%s' "$BOT_TOKEN" > "$ISOLATED_HOME/.cache/ai-aligned-gh/token"
+    chmod 600 "$ISOLATED_HOME/.cache/ai-aligned-gh/token"
+}
+clear_bot_token() {
+    rm -f "$ISOLATED_HOME/.cache/ai-aligned-gh/token"
+}
+
+# AI detected (DROID_CLI=1). Point AS_A_BOT_URL at a dead port so any device
+# flow attempt fails fast instead of hitting the network.
+run_ai() {
+    env -i \
+        HOME="$ISOLATED_HOME" \
+        PATH="$FAKE_BIN:/opt/homebrew/bin:/usr/bin:/bin" \
+        AI_ALIGNED_GH_BIN="$FAKE_BIN/gh" \
+        AS_A_BOT_URL="http://127.0.0.1:9" \
+        DROID_CLI=1 \
+        bash "$WRAPPER" "$@"
+}
+
+# No AI detected (AMI_PASSTHROUGH forces am-i-ai to report "none").
+run_human() {
+    env -i \
+        HOME="$ISOLATED_HOME" \
+        PATH="$FAKE_BIN:/opt/homebrew/bin:/usr/bin:/bin" \
+        AI_ALIGNED_GH_BIN="$FAKE_BIN/gh" \
+        AMI_PASSTHROUGH=true \
+        bash "$WRAPPER" "$@"
+}
+
+echo "=== Integration: gh auth token attribution guard ==="
+
+echo ""
+echo "--- AI + cached bot token: returns the bot token ---"
+seed_bot_token
+out=$(run_ai auth token 2>/dev/null)
+rc=$?
+if [ "$rc" -eq 0 ] && [ "$out" = "$BOT_TOKEN" ]; then
+    pass "AI gets the as-a-bot token"
+else
+    fail "expected '$BOT_TOKEN' rc=0, got '$out' rc=$rc"
+fi
+if echo "$out" | grep -q "$PERSONAL_TOKEN"; then
+    fail "personal token leaked to an AI tool"
+else
+    pass "personal token never reaches the AI tool"
+fi
+
+echo ""
+echo "--- No AI detected: personal token passes through unchanged ---"
+out=$(run_human auth token 2>/dev/null)
+rc=$?
+if [ "$rc" -eq 0 ] && [ "$out" = "$PERSONAL_TOKEN" ]; then
+    pass "human still gets their personal token"
+else
+    fail "expected '$PERSONAL_TOKEN' rc=0, got '$out' rc=$rc"
+fi
+
+echo ""
+echo "--- AI + no bot token: fails closed, no personal token ---"
+clear_bot_token
+out=$(run_ai auth token 2>/dev/null)
+rc=$?
+if [ "$rc" -ne 0 ]; then
+    pass "fails closed when no bot token is available (rc=$rc)"
+else
+    fail "expected non-zero exit when no bot token, got rc=$rc out='$out'"
+fi
+if echo "$out" | grep -q "$PERSONAL_TOKEN"; then
+    fail "personal token leaked on the no-bot-token path"
+else
+    pass "no personal token on stdout when failing closed"
+fi
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -gt 0 ] && exit 1
+exit 0

--- a/test_auth_token_attribution.sh
+++ b/test_auth_token_attribution.sh
@@ -36,6 +36,11 @@ PERSONAL_TOKEN="ghp_PERSONAL_TOKEN_SENTINEL"
 cat > "$FAKE_BIN/gh" <<EOF
 #!/bin/bash
 if [ "\$1" = "auth" ] && [ "\$2" = "token" ]; then
+    for a in "\$@"; do
+        case "\$a" in
+            -h|--help) echo "USAGE_HELP_TEXT"; exit 0 ;;
+        esac
+    done
     echo "$PERSONAL_TOKEN"
     exit 0
 fi
@@ -122,6 +127,22 @@ if echo "$out" | grep -q "$PERSONAL_TOKEN"; then
     fail "personal token leaked on the no-bot-token path"
 else
     pass "no personal token on stdout when failing closed"
+fi
+
+echo ""
+echo "--- AI + auth token --help: passes through to help, never a token ---"
+seed_bot_token
+out=$(run_ai auth token --help 2>/dev/null)
+rc=$?
+if [ "$rc" -eq 0 ] && echo "$out" | grep -q "USAGE_HELP_TEXT"; then
+    pass "help flag shows usage, not a token"
+else
+    fail "expected usage text rc=0, got '$out' rc=$rc"
+fi
+if echo "$out" | grep -qE "$BOT_TOKEN|$PERSONAL_TOKEN"; then
+    fail "a token leaked on the --help path"
+else
+    pass "no token on the --help path"
 fi
 
 echo ""


### PR DESCRIPTION
## What

Under AI detection, `gh auth token` now returns the **as-a-bot user-to-server token** instead of the user's personal token.

## Why

`gh auth token` was classified as a safe operation (`is_safe_operation`) and passed straight through to the real `gh`, handing detected AI tools the user's personal OAuth token. An agent that captured it could call the GitHub API directly — e.g. `curl -H "Authorization: token <token>"` — bypassing this wrapper entirely, so the actions were recorded as the **user** rather than as `as-a-bot[bot]` acting on their behalf.

This is the single most common circumvention path observed in real agent transcripts: blocked (or simply impatient) at the wrapper, the agent runs `TOKEN=$(gh auth token); curl …` and routes around attribution. Because the token was legitimately reachable, no amount of error-message wording at the *block* point could stop it — the leak was upstream.

## How

- Intercept `gh auth token` right after AI detection and return the as-a-bot token from `get_cached_token` (the same source the write path uses). The reflexive `gh auth token` + `curl` bypass now stays attributed to the bot.
- Fail closed when no bot token can be issued yet (app not authorized) rather than falling back to the personal token.
- Non-AI callers are unaffected: they already pass through to the real `gh` before this block and get their personal token unchanged.
- Remove `token` from `is_safe_operation` so any future fallthrough fails closed instead of leaking the personal token.
- Add an `AI_ALIGNED_GH_BIN` override to `find_real_gh` (unset in production) so token-exchange paths can be integration-tested against a fake `gh`.

## Tests

`test_auth_token_attribution.sh` (new, 5 assertions):
- AI + cached bot token → returns the bot token; personal token never on stdout.
- No AI detected → personal token passes through unchanged.
- AI + no bot token → fails closed, no personal token leaked.

Existing suites unaffected (`test_safe_operation.sh` 30/30, `test_pr_template_*` green, `test_impersonate.sh` green). The pre-existing `test_priority_order.sh` / `test_timeout.sh` failures reproduce on `main` and are environmental (process-tree AI detection picks up the running agent); not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
