### PR TITLE
Add `gh image` subcommand for uploading images and videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,15 +177,14 @@ Supported types: `png jpg jpeg gif webp svg avif mp4 mov webm`. Use `--repo owne
 ### How it works
 
 1. `gh image` computes the file's SHA-256 hash and dispatches the repo's `image-upload.yml` workflow with the hash and extension. **GitHub only lets users with write access dispatch workflows** — that's the authorization model: uploading requires the same permission as pushing code. Under an AI tool, the dispatch uses the as-a-bot token like every other write.
-2. The workflow pre-signs an R2 PUT URL that is **bound to the content hash** (the signature covers `x-amz-checksum-sha256`, so the URL physically cannot upload different content) and registers it with the as-a-bot worker, authenticated via GitHub Actions OIDC.
+2. The workflow is a secret-free relay: it proves the repository's identity to the as-a-bot worker via GitHub Actions OIDC. The worker mints an R2 PUT URL that is **bound to the content hash** (the signature covers `x-amz-checksum-sha256`, so the URL physically cannot upload different content).
 3. `gh image` polls the worker, uploads the file to the pre-signed URL, verifies it is serveable, and prints the URL (stdout carries only the URL, so agents can capture it).
 
-Storage is content-addressed (`owner/repo/<sha256>.<ext>`): re-uploading the same file returns the same URL instantly without dispatching anything, and a URL can never change content after publication.
+Storage is content-addressed (`owner/repo/<sha256>.<ext>`): re-uploading the same file returns the same URL instantly without dispatching anything, and a URL can never change content after publication. Uploads are kept for **90 days** — re-running `gh image` on the same file renews the same URL for another 90 days.
 
 ### Repository setup (one-time)
 
-1. Copy [`templates/image-upload.yml`](https://github.com/ai-ecoverse/as-a-bot/blob/main/templates/image-upload.yml) from as-a-bot to `.github/workflows/image-upload.yml`.
-2. Add Actions secrets: `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY` (an R2 API token scoped to object writes on the bucket).
+Install the [as-a-bot GitHub App](https://github.com/apps/as-a-bot) on the repository. It commits the `image-upload.yml` workflow automatically — the repository needs **no secrets and no other configuration**.
 
 See the [full design document](https://github.com/ai-ecoverse/as-a-bot/blob/main/docs/image-upload-design.md) for the architecture and trust model.
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,35 @@ gh impersonate --remove someorg/somerepo
 
 This is an explicit opt-in — the wrapper will still fail loudly for repos not in the list, so you always know when attribution is missing.
 
+## 🖼️ Uploading Images (`gh image`)
+
+`gh` cannot attach images or videos to PRs and issues ([cli/cli#12960](https://github.com/cli/cli/issues/12960)) — a real limitation for coding agents that want to include screenshots or screen recordings. The wrapper adds a `gh image` subcommand that uploads a file to an R2 bucket via the [as-a-bot](https://github.com/ai-ecoverse/as-a-bot) image-upload flow and prints a stable URL you can embed in Markdown:
+
+```bash
+$ gh image screenshot.png
+https://as-bot-worker.minivelos.workers.dev/i/owner/repo/<sha256>.png
+
+# Then embed it:
+gh pr comment 42 --body "Before/after: ![screenshot](https://.../i/owner/repo/<sha256>.png)"
+```
+
+Supported types: `png jpg jpeg gif webp svg avif mp4 mov webm`. Use `--repo owner/repo` outside a repository directory and `--timeout <seconds>` to adjust the wait (default 180s).
+
+### How it works
+
+1. `gh image` computes the file's SHA-256 hash and dispatches the repo's `image-upload.yml` workflow with the hash and extension. **GitHub only lets users with write access dispatch workflows** — that's the authorization model: uploading requires the same permission as pushing code. Under an AI tool, the dispatch uses the as-a-bot token like every other write.
+2. The workflow pre-signs an R2 PUT URL that is **bound to the content hash** (the signature covers `x-amz-checksum-sha256`, so the URL physically cannot upload different content) and registers it with the as-a-bot worker, authenticated via GitHub Actions OIDC.
+3. `gh image` polls the worker, uploads the file to the pre-signed URL, verifies it is serveable, and prints the URL (stdout carries only the URL, so agents can capture it).
+
+Storage is content-addressed (`owner/repo/<sha256>.<ext>`): re-uploading the same file returns the same URL instantly without dispatching anything, and a URL can never change content after publication.
+
+### Repository setup (one-time)
+
+1. Copy [`templates/image-upload.yml`](https://github.com/ai-ecoverse/as-a-bot/blob/main/templates/image-upload.yml) from as-a-bot to `.github/workflows/image-upload.yml`.
+2. Add Actions secrets: `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY` (an R2 API token scoped to object writes on the bucket).
+
+See the [full design document](https://github.com/ai-ecoverse/as-a-bot/blob/main/docs/image-upload-design.md) for the architecture and trust model.
+
 ## 📝 Pull Request Template Safeguard
 
 When an AI tool is detected, the wrapper refuses `gh pr create` (and its `gh pr new` alias) until the agent has explicitly checked whether the target repository defines pull request templates. This nudges agents to discover and use existing PR templates instead of opening PRs with ad-hoc descriptions.
@@ -250,6 +279,8 @@ The wrapper automatically detects:
 | `GH_TOKEN` | GitHub token override | (uses `gh auth token`) |
 | `PR_TEMPLATE_CACHE_TTL` | PR template check cache lifetime (seconds) | `3600` |
 | `PR_TEMPLATE_CACHE_DIR` | PR template check cache directory | `~/.cache/ai-aligned-gh/pr-template-checks` |
+| `GH_IMAGE_WORKFLOW` | Workflow file `gh image` dispatches | `image-upload.yml` |
+| `GH_IMAGE_TIMEOUT` | Default `gh image` wait for the upload URL (seconds) | `180` |
 | `AI_ALIGNED_GH_BIN` | Override path to the real `gh` (testing hook; unset in normal use) | (auto-detected) |
 
 ### PATH Configuration

--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ gh pr comment 42 --body "Before/after: ![screenshot](https://.../i/owner/repo/<s
 
 Supported types: `png jpg jpeg gif webp svg avif mp4 mov webm`. Use `--repo owner/repo` outside a repository directory and `--timeout <seconds>` to adjust the wait (default 180s).
 
+To make the command discoverable at the moment it matters, the wrapper prints a short stderr tip pointing at `gh image` whenever an AI agent runs `gh pr create` or `gh issue create` — agents otherwise assume image attachment is impossible and skip screenshots entirely.
+
 ### How it works
 
 1. `gh image` computes the file's SHA-256 hash and dispatches the repo's `image-upload.yml` workflow with the hash and extension. **GitHub only lets users with write access dispatch workflows** — that's the authorization model: uploading requires the same permission as pushing code. Under an AI tool, the dispatch uses the as-a-bot token like every other write.

--- a/README.md
+++ b/README.md
@@ -174,6 +174,15 @@ gh pr comment 42 --body "Before/after: ![screenshot](https://.../i/owner/repo/<s
 
 Supported types: `png jpg jpeg gif webp svg avif mp4 mov webm`. Use `--repo owner/repo` outside a repository directory and `--timeout <seconds>` to adjust the wait (default 180s).
 
+With `--markdown` (`-m`) the output is ready-to-embed Markdown instead of the bare URL, so it can be inlined directly:
+
+```bash
+gh pr comment 42 --body "Before/after: $(gh image --markdown after.png)"
+# → Before/after: ![after](https://.../i/owner/repo/<sha256>.png)
+```
+
+> **Note**: GitHub's image proxy (Camo) refuses to inline images from `*.workers.dev` hosts — they render as plain links. For inline rendering in GitHub Markdown, the as-a-bot worker should be served from a custom domain.
+
 To make the command discoverable at the moment it matters, the wrapper prints a short stderr tip pointing at `gh image` whenever an AI agent runs `gh pr create` or `gh issue create` — agents otherwise assume image attachment is impossible and skip screenshots entirely.
 
 ### How it works

--- a/executable_gh
+++ b/executable_gh
@@ -661,18 +661,20 @@ _gh_flag_takes_value() {
     return 1
 }
 
-# Detect whether the args list represents `gh pr create` (or its alias
-# `gh pr new`). Tolerates global flags before `pr`, inherited flags
-# between `pr` and the subcommand (notably `-R/--repo owner/repo`), and
-# both the `--flag value` and `--flag=value` forms. Returns 0 if the
-# invocation creates a pull request.
-is_pr_create_invocation() {
+# Detect whether the args list represents `gh <cmd> create` (or its alias
+# `gh <cmd> new`) for the given command. Tolerates global flags before the
+# command, inherited flags between the command and the subcommand (notably
+# `-R/--repo owner/repo`), and both the `--flag value` and `--flag=value`
+# forms. Returns 0 if the invocation is a create.
+_is_create_invocation_for() {
+    local target_cmd="$1"
+    shift
     local args=("$@")
     local n=${#args[@]}
     local i=0
-    local found_pr=false
+    local found_cmd=false
 
-    # Phase 1: locate the "pr" command, skipping any global flags.
+    # Phase 1: locate the target command, skipping any global flags.
     while [ $i -lt $n ]; do
         local arg="${args[$i]}"
         case "$arg" in
@@ -686,15 +688,15 @@ is_pr_create_invocation() {
                     i=$((i + 1))
                 fi
                 continue ;;
-            pr)
-                found_pr=true
+            "$target_cmd")
+                found_cmd=true
                 i=$((i + 1))
                 break ;;
             *)
                 return 1 ;;
         esac
     done
-    if ! $found_pr; then
+    if ! $found_cmd; then
         return 1
     fi
 
@@ -719,6 +721,14 @@ is_pr_create_invocation() {
         esac
     done
     return 1
+}
+
+is_pr_create_invocation() {
+    _is_create_invocation_for pr "$@"
+}
+
+is_issue_create_invocation() {
+    _is_create_invocation_for issue "$@"
 }
 # --- END PR template safeguard ---
 
@@ -1831,6 +1841,19 @@ if [ "$1" = "api" ]; then
             debug_log "Recorded PR template check for $_ptl_owner/$_ptl_repo"
         fi
     fi
+fi
+
+# gh image hint: agents composing a PR or issue often want to include a
+# screenshot or recording but assume gh cannot attach images (cli/cli#12960).
+# Point them at gh image at exactly the moment it is useful. Informational
+# only — never blocks the command.
+if is_pr_create_invocation "$@" || is_issue_create_invocation "$@"; then
+    echo "" >&2
+    echo "[TIP] Need to include a screenshot, image, or video? Upload it first:" >&2
+    echo "        gh image <file>     # prints a URL, embed it as Markdown:" >&2
+    echo "        ![description](url)" >&2
+    echo "      Run 'gh image --help' for details." >&2
+    echo "" >&2
 fi
 
 # PR template safeguard: block `gh pr create` until the agent has verified

--- a/executable_gh
+++ b/executable_gh
@@ -796,15 +796,15 @@ SUPPORTED FILE TYPES
   $IMAGE_ALLOWED_EXTENSIONS
 
 SETUP (one-time, per repository)
-  1. Copy templates/image-upload.yml from
-     https://github.com/ai-ecoverse/as-a-bot
-     to .github/workflows/image-upload.yml
-  2. Add Actions secrets: R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY
+  Install the as-a-bot GitHub App: https://github.com/apps/as-a-bot
+  The app commits the image-upload workflow automatically — no secrets
+  or other configuration are needed in the repository.
 
 The upload is gated on repository write access: gh image dispatches the
 repo's image-upload workflow, and GitHub only lets collaborators with write
 access do that. Files are stored content-addressed (owner/repo/<sha256>.<ext>),
-so re-uploading the same file returns the same URL instantly.
+so re-uploading the same file returns the same URL instantly. Uploads are
+kept for 90 days; re-running gh image on the same file renews the URL.
 EOF
 }
 
@@ -970,11 +970,11 @@ handle_image_command() {
         echo "  repository, and you need write access to dispatch it." >&2
         echo "" >&2
         echo "  One-time setup for the repository:" >&2
-        echo "  1. Copy templates/image-upload.yml from" >&2
-        echo "     https://github.com/ai-ecoverse/as-a-bot" >&2
-        echo "     to .github/workflows/image-upload.yml" >&2
-        echo "  2. Add Actions secrets: R2_ACCOUNT_ID, R2_ACCESS_KEY_ID," >&2
-        echo "     R2_SECRET_ACCESS_KEY" >&2
+        echo "  Install the as-a-bot GitHub App on $owner/$repo:" >&2
+        echo "    https://github.com/apps/as-a-bot" >&2
+        echo "  The app commits the workflow automatically — no secrets needed." >&2
+        echo "  (Manual alternative: copy templates/image-upload.yml from" >&2
+        echo "  https://github.com/ai-ecoverse/as-a-bot to .github/workflows/)" >&2
         echo "" >&2
         echo "  Original error:" >&2
         echo "  $dispatch_output" >&2

--- a/executable_gh
+++ b/executable_gh
@@ -790,6 +790,18 @@ image_hex_to_base64() {
     fi
 }
 
+# Print the final result: bare URL by default, ready-to-paste Markdown
+# with --markdown (so agents can inline it, e.g.
+# `gh pr comment 42 --body "see $(gh image --markdown shot.png)"`).
+image_format_output() {
+    local format="$1" alt="$2" url="$3"
+    if [ "$format" = "markdown" ]; then
+        echo "![${alt}](${url})"
+    else
+        echo "$url"
+    fi
+}
+
 image_usage() {
     cat <<EOF
 Upload an image or video and print a serveable URL for PR/issue Markdown.
@@ -800,7 +812,13 @@ USAGE
 FLAGS
   -R, --repo <owner/repo>   Target repository (default: current directory)
       --timeout <seconds>   How long to wait for the upload URL (default: 180)
+  -m, --markdown            Print ready-to-embed Markdown instead of the bare
+                            URL: ![<filename>](<url>)
   -h, --help                Show this help
+
+EXAMPLES
+  gh image screenshot.png
+  gh pr comment 42 --body "Before/after: \$(gh image --markdown after.png)"
 
 SUPPORTED FILE TYPES
   $IMAGE_ALLOWED_EXTENSIONS
@@ -821,12 +839,17 @@ EOF
 handle_image_command() {
     local file="" repo_spec="" timeout="${GH_IMAGE_TIMEOUT:-180}"
     local poll_interval=3
+    local output_format="url"
 
     while [ $# -gt 0 ]; do
         case "$1" in
             -h|--help)
                 image_usage
                 exit 0
+                ;;
+            -m|--markdown)
+                output_format="markdown"
+                shift
                 ;;
             -R|--repo)
                 if [ $# -lt 2 ]; then
@@ -941,7 +964,7 @@ handle_image_command() {
     # Content-addressed dedupe: identical content is already served.
     if curl -sfI "$serve_url" >/dev/null 2>&1; then
         debug_log "Content already uploaded, returning existing URL"
-        echo "$serve_url"
+        image_format_output "$output_format" "${base%.*}" "$serve_url"
         exit 0
     fi
 
@@ -1004,7 +1027,7 @@ handle_image_command() {
         case "$status" in
             uploaded)
                 # The identical content landed in the bucket already.
-                echo "$serve_url"
+                image_format_output "$output_format" "${base%.*}" "$serve_url"
                 exit 0
                 ;;
             ready)
@@ -1058,7 +1081,7 @@ handle_image_command() {
         sleep 1
     done
 
-    echo "$serve_url"
+    image_format_output "$output_format" "${base%.*}" "$serve_url"
     exit 0
 }
 # --- END gh image ---

--- a/executable_gh
+++ b/executable_gh
@@ -769,7 +769,7 @@ image_sha256_hex() {
 # Convert a hex digest to base64 (value of the x-amz-checksum-sha256 header
 # the pre-signed URL requires).
 image_hex_to_base64() {
-    if command -v xxd >/dev/null 2>&1; then
+    if command -v xxd >/dev/null 2>&1 && command -v base64 >/dev/null 2>&1; then
         printf '%s' "$1" | xxd -r -p | base64 | tr -d '\n'
     elif command -v python3 >/dev/null 2>&1; then
         python3 -c 'import sys, base64, binascii; print(base64.b64encode(binascii.unhexlify(sys.argv[1])).decode())' "$1"
@@ -861,6 +861,19 @@ handle_image_command() {
 
     if [ -z "$file" ]; then
         image_usage >&2
+        exit 1
+    fi
+
+    # Timeout drives arithmetic comparisons below — reject anything that
+    # is not a positive integer before entering the polling loop.
+    case "$timeout" in
+        ''|*[!0-9]*)
+            echo "Error: --timeout must be a positive integer (got: '$timeout')" >&2
+            exit 1
+            ;;
+    esac
+    if [ "$timeout" -le 0 ]; then
+        echo "Error: --timeout must be a positive integer (got: '$timeout')" >&2
         exit 1
     fi
 

--- a/executable_gh
+++ b/executable_gh
@@ -722,6 +722,324 @@ is_pr_create_invocation() {
 }
 # --- END PR template safeguard ---
 
+# --- BEGIN gh image ---
+# `gh image <file>` uploads an image or video to an R2 bucket via the
+# as-a-bot image-upload flow and prints a serveable URL that can be embedded
+# in PR and issue bodies. gh itself cannot attach images (cli/cli#12960).
+#
+# Flow (design: as-a-bot docs/image-upload-design.md):
+#   1. Compute the SHA-256 content hash of the file.
+#   2. Dispatch the target repo's image-upload workflow with hash + extension.
+#      GitHub only allows users with write access to dispatch workflows, so
+#      minting an upload URL requires the same permission as pushing code.
+#   3. The workflow pre-signs a checksum-bound R2 PUT URL and registers it
+#      with the as-a-bot worker.
+#   4. Poll the worker until the pre-signed URL appears, upload the file,
+#      verify it is serveable, and print the serve URL (stdout is only the
+#      URL, so agents can capture it directly).
+
+IMAGE_ALLOWED_EXTENSIONS="png jpg jpeg gif webp svg avif mp4 mov webm"
+IMAGE_WORKFLOW_FILE="${GH_IMAGE_WORKFLOW:-image-upload.yml}"
+
+image_content_type() {
+    case "$1" in
+        png)      echo "image/png" ;;
+        jpg|jpeg) echo "image/jpeg" ;;
+        gif)      echo "image/gif" ;;
+        webp)     echo "image/webp" ;;
+        svg)      echo "image/svg+xml" ;;
+        avif)     echo "image/avif" ;;
+        mp4)      echo "video/mp4" ;;
+        mov)      echo "video/quicktime" ;;
+        webm)     echo "video/webm" ;;
+        *)        echo "application/octet-stream" ;;
+    esac
+}
+
+image_sha256_hex() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" | awk '{print $1}'
+    else
+        return 1
+    fi
+}
+
+# Convert a hex digest to base64 (value of the x-amz-checksum-sha256 header
+# the pre-signed URL requires).
+image_hex_to_base64() {
+    if command -v xxd >/dev/null 2>&1; then
+        printf '%s' "$1" | xxd -r -p | base64 | tr -d '\n'
+    elif command -v python3 >/dev/null 2>&1; then
+        python3 -c 'import sys, base64, binascii; print(base64.b64encode(binascii.unhexlify(sys.argv[1])).decode())' "$1"
+    elif command -v perl >/dev/null 2>&1; then
+        perl -MMIME::Base64 -e 'print encode_base64(pack("H*", $ARGV[0]), "")' "$1"
+    else
+        return 1
+    fi
+}
+
+image_usage() {
+    cat <<EOF
+Upload an image or video and print a serveable URL for PR/issue Markdown.
+
+USAGE
+  gh image <file> [flags]
+
+FLAGS
+  -R, --repo <owner/repo>   Target repository (default: current directory)
+      --timeout <seconds>   How long to wait for the upload URL (default: 180)
+  -h, --help                Show this help
+
+SUPPORTED FILE TYPES
+  $IMAGE_ALLOWED_EXTENSIONS
+
+SETUP (one-time, per repository)
+  1. Copy templates/image-upload.yml from
+     https://github.com/ai-ecoverse/as-a-bot
+     to .github/workflows/image-upload.yml
+  2. Add Actions secrets: R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY
+
+The upload is gated on repository write access: gh image dispatches the
+repo's image-upload workflow, and GitHub only lets collaborators with write
+access do that. Files are stored content-addressed (owner/repo/<sha256>.<ext>),
+so re-uploading the same file returns the same URL instantly.
+EOF
+}
+
+handle_image_command() {
+    local file="" repo_spec="" timeout="${GH_IMAGE_TIMEOUT:-180}"
+    local poll_interval=3
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -h|--help)
+                image_usage
+                exit 0
+                ;;
+            -R|--repo)
+                if [ $# -lt 2 ]; then
+                    echo "Error: $1 requires a value" >&2
+                    exit 1
+                fi
+                repo_spec="$2"
+                shift 2
+                ;;
+            --repo=*)
+                repo_spec="${1#--repo=}"
+                shift
+                ;;
+            --timeout)
+                if [ $# -lt 2 ]; then
+                    echo "Error: $1 requires a value" >&2
+                    exit 1
+                fi
+                timeout="$2"
+                shift 2
+                ;;
+            --timeout=*)
+                timeout="${1#--timeout=}"
+                shift
+                ;;
+            -*)
+                echo "Error: unknown flag: $1" >&2
+                echo "" >&2
+                image_usage >&2
+                exit 1
+                ;;
+            *)
+                if [ -n "$file" ]; then
+                    echo "Error: unexpected argument: $1" >&2
+                    exit 1
+                fi
+                file="$1"
+                shift
+                ;;
+        esac
+    done
+
+    if [ -z "$file" ]; then
+        image_usage >&2
+        exit 1
+    fi
+
+    if [ ! -f "$file" ] || [ ! -r "$file" ]; then
+        echo "Error: file not found or not readable: $file" >&2
+        exit 1
+    fi
+
+    for tool in curl jq; do
+        if ! command -v "$tool" >/dev/null 2>&1; then
+            echo "Error: gh image requires '$tool' to be installed" >&2
+            exit 1
+        fi
+    done
+
+    local base ext
+    base=$(basename "$file")
+    case "$base" in
+        *.*)
+            ext=$(echo "${base##*.}" | tr '[:upper:]' '[:lower:]')
+            ;;
+        *)
+            echo "Error: file has no extension: $file" >&2
+            exit 1
+            ;;
+    esac
+    case " $IMAGE_ALLOWED_EXTENSIONS " in
+        *" $ext "*) ;;
+        *)
+            echo "Error: unsupported file type '.$ext'" >&2
+            echo "Supported: $IMAGE_ALLOWED_EXTENSIONS" >&2
+            exit 1
+            ;;
+    esac
+
+    local hash hash_b64
+    if ! hash=$(image_sha256_hex "$file"); then
+        echo "Error: gh image requires sha256sum or shasum" >&2
+        exit 1
+    fi
+    if ! hash_b64=$(image_hex_to_base64 "$hash"); then
+        echo "Error: gh image requires xxd, python3, or perl to encode the checksum" >&2
+        exit 1
+    fi
+
+    local owner repo
+    if ! read -r owner repo < <(get_repo_info "$repo_spec"); then
+        echo "Error: could not determine the target repository." >&2
+        echo "Run gh image inside a repository or pass --repo owner/repo." >&2
+        exit 1
+    fi
+
+    local serve_url="$BROKER_URL/i/$owner/$repo/$hash.$ext"
+
+    # Content-addressed dedupe: identical content is already served.
+    if curl -sfI "$serve_url" >/dev/null 2>&1; then
+        debug_log "Content already uploaded, returning existing URL"
+        echo "$serve_url"
+        exit 0
+    fi
+
+    # Use the as-a-bot token for the workflow dispatch when an AI tool is
+    # driving — the same attribution rules as every other write operation.
+    local dispatch_token=""
+    AI_TOOL=$(detect_ai_tool)
+    if [ "$AI_TOOL" != "none" ] && ! should_ignore_repo "$owner" "$repo"; then
+        dispatch_token=$(get_cached_token)
+        if [ -z "$dispatch_token" ]; then
+            echo "[ERROR] as-a-bot authentication required before dispatching the upload workflow." >&2
+            echo "        Authorize the app (see instructions above), then try again." >&2
+            exit 1
+        fi
+    fi
+
+    echo "Requesting upload URL via $IMAGE_WORKFLOW_FILE in $owner/$repo..." >&2
+    local dispatch_output dispatch_status
+    if [ -n "$dispatch_token" ]; then
+        dispatch_output=$(GH_TOKEN="$dispatch_token" "$GH_BIN" workflow run "$IMAGE_WORKFLOW_FILE" \
+            --repo "$owner/$repo" -f "hash=$hash" -f "ext=$ext" 2>&1)
+    else
+        dispatch_output=$("$GH_BIN" workflow run "$IMAGE_WORKFLOW_FILE" \
+            --repo "$owner/$repo" -f "hash=$hash" -f "ext=$ext" 2>&1)
+    fi
+    dispatch_status=$?
+    if [ $dispatch_status -ne 0 ]; then
+        echo "" >&2
+        echo "=================================================================" >&2
+        echo "  Image Upload Workflow Could Not Be Dispatched" >&2
+        echo "=================================================================" >&2
+        echo "" >&2
+        echo "  Repository: $owner/$repo" >&2
+        echo "" >&2
+        echo "  gh image needs the '$IMAGE_WORKFLOW_FILE' workflow in the target" >&2
+        echo "  repository, and you need write access to dispatch it." >&2
+        echo "" >&2
+        echo "  One-time setup for the repository:" >&2
+        echo "  1. Copy templates/image-upload.yml from" >&2
+        echo "     https://github.com/ai-ecoverse/as-a-bot" >&2
+        echo "     to .github/workflows/image-upload.yml" >&2
+        echo "  2. Add Actions secrets: R2_ACCOUNT_ID, R2_ACCESS_KEY_ID," >&2
+        echo "     R2_SECRET_ACCESS_KEY" >&2
+        echo "" >&2
+        echo "  Original error:" >&2
+        echo "  $dispatch_output" >&2
+        echo "" >&2
+        exit 1
+    fi
+
+    local status_url="$BROKER_URL/image-upload/status?owner=$owner&repo=$repo&hash=$hash&ext=$ext"
+    local start_time now elapsed response status upload_url
+    start_time=$(date +%s)
+    echo "Waiting for pre-signed upload URL (timeout: ${timeout}s)..." >&2
+
+    while true; do
+        response=$(curl -sS "$status_url" 2>/dev/null)
+        status=$(echo "$response" | jq -r '.status // empty' 2>/dev/null)
+
+        case "$status" in
+            uploaded)
+                # The identical content landed in the bucket already.
+                echo "$serve_url"
+                exit 0
+                ;;
+            ready)
+                break
+                ;;
+        esac
+
+        now=$(date +%s)
+        elapsed=$((now - start_time))
+        if [ "$elapsed" -ge "$timeout" ]; then
+            echo "" >&2
+            echo "Error: timed out after ${timeout}s waiting for the upload URL." >&2
+            echo "Check the workflow run:  gh run list --workflow $IMAGE_WORKFLOW_FILE --repo $owner/$repo" >&2
+            exit 1
+        fi
+        sleep "$poll_interval"
+    done
+
+    upload_url=$(echo "$response" | jq -r '.upload_url // empty')
+    if [ -z "$upload_url" ]; then
+        echo "Error: worker returned a ready status without an upload URL" >&2
+        exit 1
+    fi
+
+    # Send the headers the pre-signed URL was signed for (at minimum the
+    # checksum header that binds the upload to this exact content).
+    local -a header_args=()
+    local header_line
+    while IFS= read -r header_line; do
+        [ -n "$header_line" ] && header_args+=(-H "$header_line")
+    done < <(echo "$response" | jq -r '(.upload_headers // {}) | to_entries[] | "\(.key): \(.value)"' 2>/dev/null)
+    if [ ${#header_args[@]} -eq 0 ]; then
+        header_args=(-H "x-amz-checksum-sha256: $hash_b64")
+    fi
+    header_args+=(-H "Content-Type: $(image_content_type "$ext")")
+
+    echo "Uploading $base ($(wc -c < "$file" | tr -d ' ') bytes)..." >&2
+    if ! curl -sSf -X PUT --upload-file "$file" "${header_args[@]}" "$upload_url" -o /dev/null; then
+        echo "Error: upload failed (the pre-signed URL may have expired — try again)" >&2
+        exit 1
+    fi
+
+    # Verify the object is actually serveable before reporting success.
+    local verify_attempt=0
+    while ! curl -sfI "$serve_url" >/dev/null 2>&1; do
+        verify_attempt=$((verify_attempt + 1))
+        if [ "$verify_attempt" -ge 3 ]; then
+            echo "Error: upload completed but the file is not serveable at $serve_url" >&2
+            exit 1
+        fi
+        sleep 1
+    done
+
+    echo "$serve_url"
+    exit 0
+}
+# --- END gh image ---
+
 # Function to find the real gh executable
 find_real_gh() {
     # Test/override hook: AI_ALIGNED_GH_BIN points at the real gh explicitly.
@@ -1433,6 +1751,13 @@ if [ "$1" = "impersonate" ]; then
     echo "instead of the as-a-bot app. Attribution will appear as you,"
     echo "not as a bot acting on your behalf."
     exit 0
+fi
+
+# Handle `gh image` subcommand — upload an image/video, print a serveable URL
+if [ "$1" = "image" ]; then
+    shift
+    handle_image_command "$@"
+    # handle_image_command always exits
 fi
 
 # Detect if an AI tool is running

--- a/executable_gh
+++ b/executable_gh
@@ -1016,7 +1016,7 @@ handle_image_command() {
     fi
 
     local status_url="$BROKER_URL/image-upload/status?owner=$owner&repo=$repo&hash=$hash&ext=$ext"
-    local start_time now elapsed response status upload_url
+    local start_time now elapsed response status upload_url response_serve
     start_time=$(date +%s)
     echo "Waiting for pre-signed upload URL (timeout: ${timeout}s)..." >&2
 
@@ -1024,13 +1024,20 @@ handle_image_command() {
         response=$(curl -sS "$status_url" 2>/dev/null)
         status=$(echo "$response" | jq -r '.status // empty' 2>/dev/null)
 
+        # Prefer the worker's serve URL over the locally constructed one —
+        # it may live on the embeddable wildcard domain
+        # (repo--owner.<domain>) instead of the workers.dev host.
+        response_serve=$(echo "$response" | jq -r '.serve_url // empty' 2>/dev/null)
+
         case "$status" in
             uploaded)
                 # The identical content landed in the bucket already.
+                [ -n "$response_serve" ] && serve_url="$response_serve"
                 image_format_output "$output_format" "${base%.*}" "$serve_url"
                 exit 0
                 ;;
             ready)
+                [ -n "$response_serve" ] && serve_url="$response_serve"
                 break
                 ;;
         esac

--- a/test_image.sh
+++ b/test_image.sh
@@ -225,6 +225,17 @@ else
 fi
 rm -f "$STATE/head_ok"
 
+# Test 6b: --markdown emits ready-to-embed Markdown
+print_test "--markdown emits embeddable Markdown"
+touch "$STATE/head_ok"
+output=$(run_image "$TEST_FILE" --repo testowner/testrepo --markdown 2>/dev/null)
+if [ "$output" = "![shot]($SERVE_URL)" ]; then
+    print_pass "--markdown wrapped the URL in image Markdown"
+else
+    print_fail "--markdown output wrong. Expected: ![shot]($SERVE_URL) Got: $output"
+fi
+rm -f "$STATE/head_ok"
+
 # Test 7: full flow — dispatch, poll, upload, verify
 print_test "Full flow: dispatch, poll, upload, verify"
 printf '%s' "$HASH_B64" > "$STATE/checksum"

--- a/test_image.sh
+++ b/test_image.sh
@@ -188,6 +188,27 @@ else
     fi
 fi
 
+# Test 5b: invalid --timeout values fail
+print_test "Invalid --timeout values fail"
+if output=$(run_image "$TEST_FILE" --repo testowner/testrepo --timeout abc 2>&1); then
+    print_fail "Expected non-zero exit for --timeout abc"
+else
+    if echo "$output" | grep -q "positive integer"; then
+        print_pass "Non-numeric timeout rejected"
+    else
+        print_fail "Wrong error for non-numeric timeout. Got: $output"
+    fi
+fi
+if output=$(run_image "$TEST_FILE" --repo testowner/testrepo --timeout 0 2>&1); then
+    print_fail "Expected non-zero exit for --timeout 0"
+else
+    if echo "$output" | grep -q "positive integer"; then
+        print_pass "Zero timeout rejected"
+    else
+        print_fail "Wrong error for zero timeout. Got: $output"
+    fi
+fi
+
 # Test 6: content-addressed dedupe returns URL without dispatching
 print_test "Dedupe: already-uploaded content returns URL immediately"
 touch "$STATE/head_ok"

--- a/test_image.sh
+++ b/test_image.sh
@@ -68,7 +68,11 @@ case "$args" in
             echo '{"status":"pending"}'
         else
             checksum=$(cat "$FAKE_STATE/checksum" 2>/dev/null || echo "unset")
-            echo "{\"status\":\"ready\",\"upload_url\":\"https://acc.r2.cloudflarestorage.com/bucket/key?sig=1\",\"upload_headers\":{\"x-amz-checksum-sha256\":\"$checksum\"}}"
+            serve=""
+            if [ -f "$FAKE_STATE/serve_override" ]; then
+                serve=",\"serve_url\":\"$(cat "$FAKE_STATE/serve_override")\""
+            fi
+            echo "{\"status\":\"ready\",\"upload_url\":\"https://acc.r2.cloudflarestorage.com/bucket/key?sig=1\",\"upload_headers\":{\"x-amz-checksum-sha256\":\"$checksum\"}$serve}"
         fi
         exit 0
         ;;
@@ -261,6 +265,20 @@ else
     print_fail "Upload missing Content-Type header"
 fi
 rm -f "$STATE/workflow_args" "$STATE/put_args"
+
+# Test 7b: worker-provided serve_url (wildcard domain) wins over the
+# locally constructed one
+print_test "Worker serve_url override is preferred"
+WILDCARD_URL="https://testrepo--testowner.img.test/$HASH.png"
+printf '%s' "$WILDCARD_URL" > "$STATE/serve_override"
+printf '%s' "$HASH_B64" > "$STATE/checksum"
+output=$(run_image "$TEST_FILE" --repo testowner/testrepo 2>/dev/null)
+if [ "$output" = "$WILDCARD_URL" ]; then
+    print_pass "Printed the worker's wildcard serve URL"
+else
+    print_fail "Expected: $WILDCARD_URL Got: $output"
+fi
+rm -f "$STATE/serve_override" "$STATE/workflow_args" "$STATE/put_args"
 
 # Test 8: timeout when the worker never provides a URL
 print_test "Timeout when the offer never arrives"

--- a/test_image.sh
+++ b/test_image.sh
@@ -265,6 +265,42 @@ else
 fi
 rm -f "$STATE/pending" "$STATE/workflow_args"
 
+# Runner that simulates an AI agent (Claude env var, no passthrough)
+run_ai() {
+    CLAUDECODE=1 \
+    AS_A_BOT_URL="https://broker.test" \
+    AI_ALIGNED_GH_BIN="$FAKEBIN/gh" \
+    PATH="$FAKEBIN:$PATH" \
+    "$GH_WRAPPER" "$@"
+}
+
+# Test 9: AI agents get a gh image tip on pr create
+print_test "gh pr create shows the gh image tip for AI agents"
+output=$(run_ai pr create --repo testowner/testrepo --title t --body b 2>&1 || true)
+if echo "$output" | grep -q "gh image <file>"; then
+    print_pass "pr create surfaced the gh image tip"
+else
+    print_fail "pr create did not surface the tip. Got: $output"
+fi
+
+# Test 10: AI agents get a gh image tip on issue create
+print_test "gh issue create shows the gh image tip for AI agents"
+output=$(run_ai issue create --repo testowner/testrepo --title t --body b 2>&1 || true)
+if echo "$output" | grep -q "gh image <file>"; then
+    print_pass "issue create surfaced the gh image tip"
+else
+    print_fail "issue create did not surface the tip. Got: $output"
+fi
+
+# Test 11: read-only commands do not get the tip
+print_test "gh pr list does not show the tip"
+output=$(run_ai pr list 2>&1 || true)
+if echo "$output" | grep -q "gh image <file>"; then
+    print_fail "pr list unexpectedly surfaced the tip. Got: $output"
+else
+    print_pass "pr list stayed quiet"
+fi
+
 echo ""
 if [ "$FAILURES" -eq 0 ]; then
     echo -e "${GREEN}All gh image tests passed!${NC}"

--- a/test_image.sh
+++ b/test_image.sh
@@ -1,0 +1,254 @@
+#!/bin/bash
+
+# Test script for the `gh image` subcommand
+# Verifies help, argument validation, content-addressed dedupe, and the
+# full dispatch → poll → upload → verify flow using fake curl/gh binaries.
+
+set -e
+
+# Colors for output
+if [ -t 1 ]; then
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    BLUE='\033[0;34m'
+    CYAN='\033[0;36m'
+    NC='\033[0m' # No Color
+else
+    RED=''
+    GREEN=''
+    BLUE=''
+    CYAN=''
+    NC=''
+fi
+
+print_test() {
+    echo -e "${CYAN}[TEST]${NC} $*"
+}
+
+print_pass() {
+    echo -e "${GREEN}[PASS]${NC} $*"
+}
+
+print_fail() {
+    echo -e "${RED}[FAIL]${NC} $*"
+    FAILURES=$((FAILURES + 1))
+}
+
+print_info() {
+    echo -e "${BLUE}[INFO]${NC} $*"
+}
+
+FAILURES=0
+
+echo ""
+echo -e "${BLUE}=== gh image Test Suite ===${NC}"
+echo ""
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+GH_WRAPPER="$SCRIPT_DIR/executable_gh"
+
+# Isolated HOME + workspace with fake binaries
+HOME=$(mktemp -d)
+export HOME
+WORK=$(mktemp -d)
+trap 'rm -rf "$HOME" "$WORK"' EXIT
+
+FAKEBIN="$WORK/bin"
+STATE="$WORK/state"
+mkdir -p "$FAKEBIN" "$STATE"
+export FAKE_STATE="$STATE"
+
+# Fake curl: simulates the as-a-bot worker + R2
+cat > "$FAKEBIN/curl" <<'FAKE'
+#!/bin/bash
+args="$*"
+case "$args" in
+    *image-upload/status*)
+        if [ -f "$FAKE_STATE/pending" ]; then
+            echo '{"status":"pending"}'
+        else
+            checksum=$(cat "$FAKE_STATE/checksum" 2>/dev/null || echo "unset")
+            echo "{\"status\":\"ready\",\"upload_url\":\"https://acc.r2.cloudflarestorage.com/bucket/key?sig=1\",\"upload_headers\":{\"x-amz-checksum-sha256\":\"$checksum\"}}"
+        fi
+        exit 0
+        ;;
+esac
+if echo "$args" | grep -q "PUT"; then
+    echo "$args" > "$FAKE_STATE/put_args"
+    exit 0
+fi
+# HEAD probe (dedupe before upload, verification after)
+if echo "$args" | grep -q -- "-sfI"; then
+    if [ -f "$FAKE_STATE/head_ok" ] || [ -f "$FAKE_STATE/put_args" ]; then
+        exit 0
+    fi
+    exit 22
+fi
+exit 0
+FAKE
+chmod +x "$FAKEBIN/curl"
+
+# Fake gh: records workflow dispatches
+cat > "$FAKEBIN/gh" <<'FAKE'
+#!/bin/bash
+if [ "$1" = "workflow" ] && [ "$2" = "run" ]; then
+    echo "$@" > "$FAKE_STATE/workflow_args"
+    exit 0
+fi
+exit 0
+FAKE
+chmod +x "$FAKEBIN/gh"
+
+run_image() {
+    AMI_PASSTHROUGH=true \
+    AS_A_BOT_URL="https://broker.test" \
+    AI_ALIGNED_GH_BIN="$FAKEBIN/gh" \
+    PATH="$FAKEBIN:$PATH" \
+    "$GH_WRAPPER" image "$@"
+}
+
+# Hex-to-base64 with the same fallbacks the wrapper uses
+hex_to_b64() {
+    if command -v xxd >/dev/null 2>&1; then
+        printf '%s' "$1" | xxd -r -p | base64 | tr -d '\n'
+    elif command -v python3 >/dev/null 2>&1; then
+        python3 -c 'import sys, base64, binascii; print(base64.b64encode(binascii.unhexlify(sys.argv[1])).decode())' "$1"
+    else
+        perl -MMIME::Base64 -e 'print encode_base64(pack("H*", $ARGV[0]), "")' "$1"
+    fi
+}
+
+# Test fixture: a small "png"
+TEST_FILE="$WORK/shot.png"
+printf 'not-really-a-png' > "$TEST_FILE"
+HASH=$(sha256sum "$TEST_FILE" | awk '{print $1}')
+HASH_B64=$(hex_to_b64 "$HASH")
+if [ -z "$HASH_B64" ]; then
+    echo "Could not compute base64 checksum (need xxd, python3, or perl)" >&2
+    exit 1
+fi
+SERVE_URL="https://broker.test/i/testowner/testrepo/$HASH.png"
+
+# Test 1: --help prints usage
+print_test "--help prints usage"
+output=$(run_image --help 2>&1)
+if echo "$output" | grep -q "USAGE" && echo "$output" | grep -q "gh image <file>"; then
+    print_pass "--help shows usage"
+else
+    print_fail "--help did not show usage. Got: $output"
+fi
+
+# Test 2: no arguments fails with usage
+print_test "No arguments fails with usage"
+if output=$(run_image 2>&1); then
+    print_fail "Expected non-zero exit for missing file"
+else
+    if echo "$output" | grep -q "USAGE"; then
+        print_pass "Missing file shows usage and fails"
+    else
+        print_fail "Missing file did not show usage. Got: $output"
+    fi
+fi
+
+# Test 3: nonexistent file fails
+print_test "Nonexistent file fails"
+if output=$(run_image /does/not/exist.png 2>&1); then
+    print_fail "Expected non-zero exit for nonexistent file"
+else
+    if echo "$output" | grep -q "not found"; then
+        print_pass "Nonexistent file rejected"
+    else
+        print_fail "Wrong error for nonexistent file. Got: $output"
+    fi
+fi
+
+# Test 4: unsupported extension fails
+print_test "Unsupported extension fails"
+printf 'x' > "$WORK/evil.exe"
+if output=$(run_image "$WORK/evil.exe" --repo testowner/testrepo 2>&1); then
+    print_fail "Expected non-zero exit for .exe"
+else
+    if echo "$output" | grep -q "unsupported file type"; then
+        print_pass ".exe rejected"
+    else
+        print_fail "Wrong error for .exe. Got: $output"
+    fi
+fi
+
+# Test 5: file without extension fails
+print_test "File without extension fails"
+printf 'x' > "$WORK/noext"
+if output=$(run_image "$WORK/noext" --repo testowner/testrepo 2>&1); then
+    print_fail "Expected non-zero exit for extensionless file"
+else
+    if echo "$output" | grep -q "no extension"; then
+        print_pass "Extensionless file rejected"
+    else
+        print_fail "Wrong error for extensionless file. Got: $output"
+    fi
+fi
+
+# Test 6: content-addressed dedupe returns URL without dispatching
+print_test "Dedupe: already-uploaded content returns URL immediately"
+touch "$STATE/head_ok"
+output=$(run_image "$TEST_FILE" --repo testowner/testrepo 2>/dev/null)
+if [ "$output" = "$SERVE_URL" ]; then
+    print_pass "Dedupe returned the content-addressed URL"
+else
+    print_fail "Dedupe URL mismatch. Expected: $SERVE_URL Got: $output"
+fi
+if [ ! -f "$STATE/workflow_args" ]; then
+    print_pass "Dedupe did not dispatch the workflow"
+else
+    print_fail "Dedupe dispatched the workflow unexpectedly"
+fi
+rm -f "$STATE/head_ok"
+
+# Test 7: full flow — dispatch, poll, upload, verify
+print_test "Full flow: dispatch, poll, upload, verify"
+printf '%s' "$HASH_B64" > "$STATE/checksum"
+output=$(run_image "$TEST_FILE" --repo testowner/testrepo 2>/dev/null)
+if [ "$output" = "$SERVE_URL" ]; then
+    print_pass "Full flow printed the serve URL"
+else
+    print_fail "Full flow URL mismatch. Expected: $SERVE_URL Got: $output"
+fi
+if [ -f "$STATE/workflow_args" ] && grep -q "workflow run image-upload.yml --repo testowner/testrepo -f hash=$HASH -f ext=png" "$STATE/workflow_args"; then
+    print_pass "Workflow dispatched with hash and extension"
+else
+    print_fail "Workflow dispatch args wrong. Got: $(cat "$STATE/workflow_args" 2>/dev/null)"
+fi
+if [ -f "$STATE/put_args" ] && grep -q "x-amz-checksum-sha256: $HASH_B64" "$STATE/put_args"; then
+    print_pass "Upload sent the checksum header from the offer"
+else
+    print_fail "Upload missing checksum header. Got: $(cat "$STATE/put_args" 2>/dev/null)"
+fi
+if grep -q "Content-Type: image/png" "$STATE/put_args" 2>/dev/null; then
+    print_pass "Upload sent the right Content-Type"
+else
+    print_fail "Upload missing Content-Type header"
+fi
+rm -f "$STATE/workflow_args" "$STATE/put_args"
+
+# Test 8: timeout when the worker never provides a URL
+print_test "Timeout when the offer never arrives"
+touch "$STATE/pending"
+if output=$(run_image "$TEST_FILE" --repo testowner/testrepo --timeout 1 2>&1); then
+    print_fail "Expected non-zero exit on timeout"
+else
+    if echo "$output" | grep -q "timed out"; then
+        print_pass "Timed out with a helpful error"
+    else
+        print_fail "Wrong timeout error. Got: $output"
+    fi
+fi
+rm -f "$STATE/pending" "$STATE/workflow_args"
+
+echo ""
+if [ "$FAILURES" -eq 0 ]; then
+    echo -e "${GREEN}All gh image tests passed!${NC}"
+    exit 0
+else
+    echo -e "${RED}$FAILURES gh image test(s) failed${NC}"
+    exit 1
+fi

--- a/test_pr_template_safeguard.sh
+++ b/test_pr_template_safeguard.sh
@@ -18,6 +18,7 @@ eval "$(extract_block pr_template_check_is_fresh)"
 eval "$(extract_block record_pr_template_check)"
 eval "$(extract_block extract_pr_template_repo_from_api_args)"
 eval "$(extract_block _gh_flag_takes_value)"
+eval "$(extract_block _is_create_invocation_for)"
 eval "$(extract_block is_pr_create_invocation)"
 
 # Use an isolated cache dir for the tests.


### PR DESCRIPTION
## Problem

`gh` can't attach images to a PR or issue ([cli/cli#12960](https://github.com/cli/cli/issues/12960)), which is a real limitation for coding agents that want to include screenshots or recordings. This adds a `gh image` subcommand to the wrapper that uploads a file through the as-a-bot image-upload flow and prints a stable, serveable URL for Markdown embedding.

Companion PR: worker endpoints + auto-installed workflow in ai-ecoverse/as-a-bot#15 (see `docs/image-upload-design.md` there for the full design and trust model).

## Usage

```bash
$ gh image screenshot.png
https://as-bot-worker.minivelos.workers.dev/i/owner/repo/<sha256>.png
```

Flags: `--repo owner/repo` (default: current directory), `--timeout <seconds>` (default 180, validated). Supported types: `png jpg jpeg gif webp svg avif mp4 mov webm`. stdout carries only the URL, so agents can capture it directly; progress goes to stderr.

**Discoverability**: when an AI agent runs `gh pr create` or `gh issue create`, the wrapper prints a short stderr tip pointing at `gh image` — agents otherwise assume image attachment is impossible and skip screenshots entirely. Informational only, never blocks, and humans never see it.

## How it works

1. Compute the file's SHA-256. **Content-addressed dedupe**: if `HEAD /i/<owner>/<repo>/<hash>.<ext>` already exists, print the URL and stop — nothing is dispatched.
2. Dispatch the repo's `image-upload.yml` workflow (auto-installed by the as-a-bot app; the repo needs **no secrets**) with `hash` + `ext`. GitHub only lets users with write access dispatch workflows, so uploading requires the same permission as pushing code. Under an AI tool the dispatch uses the as-a-bot token (same attribution rules as every other write; `gh impersonate` list honored).
3. Poll the as-a-bot worker for the pre-signed, checksum-bound R2 PUT URL it mints (3s interval).
4. Upload with the offer's signed headers (`x-amz-checksum-sha256` — a stolen URL can only upload this exact content), verify the object is serveable, print the URL.

Uploads are kept for **90 days**; re-running `gh image` on the same file renews the identical URL. Clear guidance is printed when the workflow can't be dispatched (install the app) and on timeout (points at `gh run list`).

## Changes

- `executable_gh` — `gh image` handler + dispatch hook (does its own AI detection for token selection); `is_pr_create_invocation` generalized to `_is_create_invocation_for` so the same flag-tolerant parser powers the new create-time `gh image` tip for both `pr` and `issue`
- `test_image.sh` — 18 assertions using fake `curl`/`gh` binaries: help, argument validation (including `--timeout`), dedupe short-circuit, full dispatch→poll→upload→verify flow (checksum and Content-Type headers), timeout, and tip behavior (shown on pr/issue create, absent on read-only commands)
- `test_pr_template_safeguard.sh` — extract the new helper into its eval sandbox (also fixes `_gh_flag_takes_value` having been silently absent there)
- README — usage section, tip note, new env vars (`GH_IMAGE_WORKFLOW`, `GH_IMAGE_TIMEOUT`)

All suites pass (`test_image.sh`, `test_pr_template_safeguard.sh` 41/41, `test_pr_template_integration.sh`, `test_impersonate.sh`, `test_safe_operation.sh`); shellcheck-clean at CI severity.

## Repo setup (one-time)

Install the [as-a-bot GitHub App](https://github.com/apps/as-a-bot) — it commits the workflow automatically. No secrets, no other configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EG3kJAbgqpMAcoTiErGysE