### PR TITLE
Add `gh image --html` output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,22 +166,23 @@ This is an explicit opt-in — the wrapper will still fail loudly for repos not 
 
 ```bash
 $ gh image screenshot.png
-https://as-bot-worker.minivelos.workers.dev/i/owner/repo/<sha256>.png
+https://repo--owner.agentbin.net/<sha256>.png
 
 # Then embed it:
-gh pr comment 42 --body "Before/after: ![screenshot](https://.../i/owner/repo/<sha256>.png)"
+gh pr comment 42 --body "Before/after: ![screenshot](https://repo--owner.agentbin.net/<sha256>.png)"
 ```
 
 Supported types: `png jpg jpeg gif webp svg avif mp4 mov webm`. Use `--repo owner/repo` outside a repository directory and `--timeout <seconds>` to adjust the wait (default 180s).
 
-With `--markdown` (`-m`) the output is ready-to-embed Markdown instead of the bare URL, so it can be inlined directly:
+With `--markdown` (`-m`) the output is ready-to-embed Markdown, and with `--html` it is an `<img>` tag — either can be inlined directly:
 
 ```bash
 gh pr comment 42 --body "Before/after: $(gh image --markdown after.png)"
-# → Before/after: ![after](https://.../i/owner/repo/<sha256>.png)
-```
+# → Before/after: ![after](https://repo--owner.agentbin.net/<sha256>.png)
 
-> **Note**: GitHub's image proxy (Camo) refuses to inline images from `*.workers.dev` hosts — they render as plain links. For inline rendering in GitHub Markdown, the as-a-bot worker should be served from a custom domain.
+gh pr comment 42 --body "Before/after: $(gh image --html after.png)"
+# → Before/after: <img src="https://repo--owner.agentbin.net/<sha256>.png" alt="after">
+```
 
 To make the command discoverable at the moment it matters, the wrapper prints a short stderr tip pointing at `gh image` whenever an AI agent runs `gh pr create` or `gh issue create` — agents otherwise assume image attachment is impossible and skip screenshots entirely.
 

--- a/executable_gh
+++ b/executable_gh
@@ -790,6 +790,12 @@ image_hex_to_base64() {
     fi
 }
 
+# Escape HTML attribute metacharacters — the alt text derives from the
+# filename, which may contain ", <, >, or &.
+image_html_escape() {
+    printf '%s' "$1" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/"/\&quot;/g'
+}
+
 # Print the final result: bare URL by default, ready-to-paste Markdown
 # with --markdown or an <img> tag with --html (so agents can inline it,
 # e.g. `gh pr comment 42 --body "see $(gh image --markdown shot.png)"`).
@@ -800,7 +806,7 @@ image_format_output() {
             echo "![${alt}](${url})"
             ;;
         html)
-            echo "<img src=\"${url}\" alt=\"${alt}\">"
+            echo "<img src=\"$(image_html_escape "$url")\" alt=\"$(image_html_escape "$alt")\">"
             ;;
         *)
             echo "$url"
@@ -856,10 +862,18 @@ handle_image_command() {
                 exit 0
                 ;;
             -m|--markdown)
+                if [ "$output_format" = "html" ]; then
+                    echo "Error: --markdown and --html are mutually exclusive" >&2
+                    exit 1
+                fi
                 output_format="markdown"
                 shift
                 ;;
             --html)
+                if [ "$output_format" = "markdown" ]; then
+                    echo "Error: --markdown and --html are mutually exclusive" >&2
+                    exit 1
+                fi
                 output_format="html"
                 shift
                 ;;

--- a/executable_gh
+++ b/executable_gh
@@ -791,15 +791,21 @@ image_hex_to_base64() {
 }
 
 # Print the final result: bare URL by default, ready-to-paste Markdown
-# with --markdown (so agents can inline it, e.g.
-# `gh pr comment 42 --body "see $(gh image --markdown shot.png)"`).
+# with --markdown or an <img> tag with --html (so agents can inline it,
+# e.g. `gh pr comment 42 --body "see $(gh image --markdown shot.png)"`).
 image_format_output() {
     local format="$1" alt="$2" url="$3"
-    if [ "$format" = "markdown" ]; then
-        echo "![${alt}](${url})"
-    else
-        echo "$url"
-    fi
+    case "$format" in
+        markdown)
+            echo "![${alt}](${url})"
+            ;;
+        html)
+            echo "<img src=\"${url}\" alt=\"${alt}\">"
+            ;;
+        *)
+            echo "$url"
+            ;;
+    esac
 }
 
 image_usage() {
@@ -814,6 +820,8 @@ FLAGS
       --timeout <seconds>   How long to wait for the upload URL (default: 180)
   -m, --markdown            Print ready-to-embed Markdown instead of the bare
                             URL: ![<filename>](<url>)
+      --html                Print an HTML tag instead of the bare URL:
+                            <img src="<url>" alt="<filename>">
   -h, --help                Show this help
 
 EXAMPLES
@@ -849,6 +857,10 @@ handle_image_command() {
                 ;;
             -m|--markdown)
                 output_format="markdown"
+                shift
+                ;;
+            --html)
+                output_format="html"
                 shift
                 ;;
             -R|--repo)

--- a/test_image.sh
+++ b/test_image.sh
@@ -247,6 +247,30 @@ if [ "$output" = "<img src=\"$SERVE_URL\" alt=\"shot\">" ]; then
 else
     print_fail "--html output wrong. Got: $output"
 fi
+
+# Test 6d: --html escapes attribute metacharacters in the alt text
+print_test "--html escapes filename-derived alt text"
+WEIRD_FILE="$WORK/we\"ird & <file>.png"
+cp "$TEST_FILE" "$WEIRD_FILE"
+output=$(run_image "$WEIRD_FILE" --repo testowner/testrepo --html 2>/dev/null)
+if echo "$output" | grep -qF 'alt="we&quot;ird &amp; &lt;file&gt;"'; then
+    print_pass "alt text is HTML-escaped"
+else
+    print_fail "alt text not escaped. Got: $output"
+fi
+rm -f "$WEIRD_FILE"
+
+# Test 6e: --markdown and --html are mutually exclusive
+print_test "--markdown and --html together fail"
+if output=$(run_image "$TEST_FILE" --repo testowner/testrepo --markdown --html 2>&1); then
+    print_fail "Expected non-zero exit for conflicting format flags"
+else
+    if echo "$output" | grep -q "mutually exclusive"; then
+        print_pass "Conflicting format flags rejected"
+    else
+        print_fail "Wrong error for conflicting flags. Got: $output"
+    fi
+fi
 rm -f "$STATE/head_ok"
 
 # Test 7: full flow — dispatch, poll, upload, verify

--- a/test_image.sh
+++ b/test_image.sh
@@ -238,6 +238,15 @@ if [ "$output" = "![shot]($SERVE_URL)" ]; then
 else
     print_fail "--markdown output wrong. Expected: ![shot]($SERVE_URL) Got: $output"
 fi
+
+# Test 6c: --html emits an <img> tag
+print_test "--html emits an <img> tag"
+output=$(run_image "$TEST_FILE" --repo testowner/testrepo --html 2>/dev/null)
+if [ "$output" = "<img src=\"$SERVE_URL\" alt=\"shot\">" ]; then
+    print_pass "--html wrapped the URL in an img tag"
+else
+    print_fail "--html output wrong. Got: $output"
+fi
 rm -f "$STATE/head_ok"
 
 # Test 7: full flow — dispatch, poll, upload, verify


### PR DESCRIPTION
Follow-up to #64. `gh image --html` prints an `<img>` tag instead of the bare URL, alongside the existing `--markdown`:

```bash
gh pr comment 42 --body "see $(gh image --html shot.png)"
# → see ``&lt;img src="https://repo--owner.agentbin.net/&lt;sha256&gt;.png" alt="shot"&gt;``
```

Also refreshes the README examples to the agentbin.net serve URLs and drops the stale workers.dev/Camo note (serving moved to the wildcard domain in ai-ecoverse/as-a-bot#20).

20 test assertions pass; shellcheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EG3kJAbgqpMAcoTiErGysE

---
_Generated by [Claude Code](https://claude.ai/code/session_01EG3kJAbgqpMAcoTiErGysE)_