### PR TITLE
Fix gh image video markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ gh pr comment 42 --body "Before/after: ![screenshot](https://repo--owner.agentbi
 
 Supported types: `png jpg jpeg gif webp svg avif mp4 mov webm`. Use `--repo owner/repo` outside a repository directory and `--timeout <seconds>` to adjust the wait (default 180s).
 
-With `--markdown` (`-m`) the output is ready-to-embed Markdown, and with `--html` it is an `<img>` tag — either can be inlined directly:
+With `--markdown` (`-m`) the output is ready-to-embed markup, and with `--html` it is an HTML tag. Images use image markup; videos use labelled links because GitHub rejects externally hosted video through its image proxy and strips external `<video>` elements. The default bare-URL output is unchanged:
 
 ```bash
 gh pr comment 42 --body "Before/after: $(gh image --markdown after.png)"
@@ -186,6 +186,13 @@ gh pr comment 42 --body "Before/after: $(gh image --markdown after.png)"
 
 gh pr comment 42 --body "Before/after: $(gh image --html after.png)"
 # → Before/after: <img src="https://repo--owner.agentbin.net/<sha256>.png" alt="after">
+
+# Video output stays clickable instead of producing broken image markup
+gh image --markdown demo.mp4
+# → [demo.mp4](https://repo--owner.agentbin.net/<sha256>.mp4)
+
+gh image --html demo.mp4
+# → <a href="https://repo--owner.agentbin.net/<sha256>.mp4">demo.mp4</a>
 ```
 
 To make the command discoverable at the moment it matters, the wrapper prints a short stderr tip pointing at `gh image` whenever an AI agent runs `gh pr create` or `gh issue create` — agents otherwise assume image attachment is impossible and skip screenshots entirely.

--- a/executable_gh
+++ b/executable_gh
@@ -796,11 +796,30 @@ image_html_escape() {
     printf '%s' "$1" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/"/\&quot;/g'
 }
 
-# Print the final result: bare URL by default, ready-to-paste Markdown
-# with --markdown or an <img> tag with --html (so agents can inline it,
-# e.g. `gh pr comment 42 --body "see $(gh image --markdown shot.png)"`).
+# Print the final result: bare URL by default, or ready-to-paste markup.
+# Images use image markup; videos use links because GitHub rejects external
+# video through camo and strips external <video> elements from comments.
 image_format_output() {
-    local format="$1" alt="$2" url="$3"
+    local format="$1" base="$2" url="$3" ext="$4"
+    local alt="${base%.*}"
+
+    case "$ext" in
+        mp4|mov|webm)
+            case "$format" in
+                markdown)
+                    echo "[${base}](${url})"
+                    ;;
+                html)
+                    echo "<a href=\"$(image_html_escape "$url")\">$(image_html_escape "$base")</a>"
+                    ;;
+                *)
+                    echo "$url"
+                    ;;
+            esac
+            return
+            ;;
+    esac
+
     case "$format" in
         markdown)
             echo "![${alt}](${url})"
@@ -825,9 +844,10 @@ FLAGS
   -R, --repo <owner/repo>   Target repository (default: current directory)
       --timeout <seconds>   How long to wait for the upload URL (default: 180)
   -m, --markdown            Print ready-to-embed Markdown instead of the bare
-                            URL: ![<filename>](<url>)
+                            URL. Images use ![<name>](<url>); videos use
+                            [<filename>](<url>).
       --html                Print an HTML tag instead of the bare URL:
-                            <img src="<url>" alt="<filename>">
+                            <img> for images; a labelled <a> link for videos.
   -h, --help                Show this help
 
 EXAMPLES
@@ -990,7 +1010,7 @@ handle_image_command() {
     # Content-addressed dedupe: identical content is already served.
     if curl -sfI "$serve_url" >/dev/null 2>&1; then
         debug_log "Content already uploaded, returning existing URL"
-        image_format_output "$output_format" "${base%.*}" "$serve_url"
+        image_format_output "$output_format" "$base" "$serve_url" "$ext"
         exit 0
     fi
 
@@ -1059,7 +1079,7 @@ handle_image_command() {
             uploaded)
                 # The identical content landed in the bucket already.
                 [ -n "$response_serve" ] && serve_url="$response_serve"
-                image_format_output "$output_format" "${base%.*}" "$serve_url"
+                image_format_output "$output_format" "$base" "$serve_url" "$ext"
                 exit 0
                 ;;
             ready)
@@ -1114,7 +1134,7 @@ handle_image_command() {
         sleep 1
     done
 
-    image_format_output "$output_format" "${base%.*}" "$serve_url"
+    image_format_output "$output_format" "$base" "$serve_url" "$ext"
     exit 0
 }
 # --- END gh image ---

--- a/test_image.sh
+++ b/test_image.sh
@@ -260,7 +260,35 @@ else
 fi
 rm -f "$WEIRD_FILE"
 
-# Test 6e: --markdown and --html are mutually exclusive
+# Tests 6e-6f: every video type uses labelled links, never media markup
+for video_ext in mp4 mov webm; do
+    VIDEO_FILE="$WORK/demo.$video_ext"
+    VIDEO_URL="https://broker.test/i/testowner/testrepo/$HASH.$video_ext"
+    cp "$TEST_FILE" "$VIDEO_FILE"
+
+    print_test "Video .$video_ext --markdown emits a labelled link"
+    output=$(run_image "$VIDEO_FILE" --repo testowner/testrepo --markdown 2>/dev/null)
+    if [ "$output" = "[demo.$video_ext]($VIDEO_URL)" ]; then
+        print_pass "Video .$video_ext --markdown emitted a labelled link"
+    else
+        print_fail "Video .$video_ext --markdown output wrong. Got: $output"
+    fi
+
+    print_test "Video .$video_ext --html emits a labelled anchor"
+    output=$(run_image "$VIDEO_FILE" --repo testowner/testrepo --html 2>/dev/null)
+    if [ "$output" = "<a href=\"$VIDEO_URL\">demo.$video_ext</a>" ]; then
+        print_pass "Video .$video_ext --html emitted a labelled anchor"
+    else
+        print_fail "Video .$video_ext --html output wrong. Got: $output"
+    fi
+    if echo "$output" | grep -Eq '<(img|video)( |>)'; then
+        print_fail "Video .$video_ext --html emitted media markup. Got: $output"
+    else
+        print_pass "Video .$video_ext --html avoided stripped or broken media markup"
+    fi
+done
+
+# Test 6g: --markdown and --html are mutually exclusive
 print_test "--markdown and --html together fail"
 if output=$(run_image "$TEST_FILE" --repo testowner/testrepo --markdown --html 2>&1); then
     print_fail "Expected non-zero exit for conflicting format flags"


### PR DESCRIPTION
## Summary

- make gh image --markdown emit a labelled link for MP4, MOV, and WebM files
- make gh image --html emit a labelled anchor for video files
- preserve existing image markup and bare-URL behavior
- add regression coverage for every supported video extension

## Why video output is a link

GitHub rejects externally hosted video through camo, so image Markdown for an MP4 produces a broken image. GitHub also strips external <video> elements. A labelled direct link is therefore the best achievable result from a CLI: it is intentionally not an inline player, but the linked H.264 MP4 plays directly when opened.

## Demo

The patched executable_gh from this branch generated the following markup for the recording. This PR body dogfoods the fix:

[gh-image-video-markup-demo.mp4](https://ai-aligned-gh--ai-ecoverse.agentbin.net/9b9fbd5caf0505e9165d0dbb4ae358e22bca29dd67e5555b0122eaa62c4fcbb9.mp4)

The short terminal recording runs gh image --markdown demo.mp4 before and after the fix. It shows the old guaranteed-broken image markup changing to the new labelled link.

## Rendered DOM evidence

Measured against the live GitHub-rendered markup:

- labelledLinkCount=1
- videoElementCount=0
- camoRewritten=false
- brokenImageCount=0

## Verification

- shellcheck --severity=warning executable_gh *.sh
- executable-bit checks from the ShellCheck workflow
- ./test_image.sh
- ./test.sh
- ./test_timeout.sh (legacy assertions still print while the script exits 0; unchanged and unrelated)
- git diff --check
