### PR TITLE
Fix device flow rotation: reuse the pending code instead of re-minting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,3 +40,6 @@ jobs:
       run: |
         export PATH="$HOME/.local/bin:$PATH"
         ./test_timeout.sh
+
+    - name: Run device flow reuse tests
+      run: ./test_device_flow_reuse.sh

--- a/executable_gh
+++ b/executable_gh
@@ -1626,111 +1626,220 @@ poll_for_token_background() {
     done
 }
 
+# Try a single foreground poll of a pending device flow. If the human has
+# already authorized the code, this picks the token up immediately instead of
+# making the next invocation race the background poller.
+#
+# Returns:
+#   0 - token acquired (printed to stdout, saved to the cache file)
+#   1 - still pending (authorization_pending / slow_down / transient error)
+#   2 - flow is dead at the broker (denied/expired); state cleaned up, the
+#       caller may mint a fresh flow
+poll_pending_flow_once() {
+    local state_file=$1
+    local cache_file=$2
+
+    local device_code
+    device_code=$(jq -r '.device_code // empty' "$state_file" 2>/dev/null)
+    if [ -z "$device_code" ]; then
+        return 1
+    fi
+
+    local response
+    response=$(curl -sS -X POST "${BROKER_URL}/user-token/poll" \
+        -H "Content-Type: application/json" \
+        -d "{\"device_code\":\"${device_code}\"}" 2>/dev/null)
+
+    local access_token
+    access_token=$(echo "$response" | jq -r '.access_token // empty' 2>/dev/null)
+    if [ -n "$access_token" ]; then
+        echo "$access_token" > "$cache_file"
+        chmod 600 "$cache_file"
+        rm -f "$state_file" "${state_file}.status"
+        debug_log "Foreground poll picked up a completed authorization"
+        echo "$access_token"
+        return 0
+    fi
+
+    local error
+    error=$(echo "$response" | jq -r '.error // empty' 2>/dev/null)
+    case "$error" in
+        ''|authorization_pending|slow_down|server_error)
+            # Not authorized yet, or the broker was unreachable — either way
+            # the flow may still succeed, so keep it alive.
+            return 1
+            ;;
+        *)
+            # access_denied, expired_token, incorrect device code, ...
+            debug_log "Pending device flow is dead at the broker: $error"
+            echo "[ERROR] Previous authentication failed: $error" >&2
+            rm -f "$state_file" "${state_file}.status"
+            return 2
+            ;;
+    esac
+}
+
 # Function to get or create cached token
 get_cached_token() {
     local cache_dir="$HOME/.cache/ai-aligned-gh"
     local state_dir="$HOME/.config/ai-aligned-gh/auth"
     local cache_file="$cache_dir/token"
     local state_file="$state_dir/device_flow.json"
-    
+
     # Create directories if they don't exist
     mkdir -p "$cache_dir" "$state_dir"
-    
-    # Check if cached token exists and is still valid
+
+    # A completed background exchange saves the token to $cache_file, writes
+    # "completed" to ${state_file}.status, and deletes $state_file itself
+    # (see poll_for_token_background). Consume the marker here, BEFORE any
+    # state-file checks: gating it on $state_file existing made the
+    # "completed" branch unreachable in exactly the case it was written for.
+    if [ -f "$cache_file" ] && [ -f "${state_file}.status" ] &&
+        [ "$(cat "${state_file}.status" 2>/dev/null)" = "completed" ]; then
+        debug_log "Background device flow completed; consuming status marker"
+        rm -f "${state_file}.status"
+    fi
+
+    # Check if cached token exists and is still usable
     if [ -f "$cache_file" ]; then
         local cached_token
         cached_token=$(cat "$cache_file")
-        
-        # Verify token is still valid and check its type
-        local rate_limit
-        
-        if GH_TOKEN="$cached_token" "$GH_BIN" api user >/dev/null 2>&1; then
+
+        # Verify the token. Only an explicit HTTP 401 proves it is dead —
+        # rate limiting (HTTP 403/429), network failures, and server errors
+        # say nothing about validity. Treating any failure as "invalid"
+        # deleted freshly exchanged tokens and re-minted a device flow on
+        # every invocation, burning each code right after the human
+        # authorized it.
+        local api_output api_exit
+        api_output=$(GH_TOKEN="$cached_token" "$GH_BIN" api user 2>&1)
+        api_exit=$?
+
+        if [ "$api_exit" -eq 0 ]; then
             # Check if this is a user-to-server token (ghu_ prefix)
             if [[ "$cached_token" == ghu_* ]]; then
                 debug_log "Using valid user-to-server token (ghu_ prefix)"
-                
+
                 # Optionally check rate limit to confirm it's a proper GitHub App token
                 if [ "$DEBUG" = "true" ]; then
+                    local rate_limit
                     rate_limit=$(GH_TOKEN="$cached_token" "$GH_BIN" api rate_limit --jq '.rate.limit' 2>/dev/null)
                     debug_log "Token rate limit: $rate_limit (15000=GitHub App user token, 5000=OAuth token)"
                 fi
             else
                 debug_log "WARNING: Token doesn't have ghu_ prefix, may not have app attribution"
             fi
-            
+
             echo "$cached_token"
             return 0
-        else
-            debug_log "Cached token is invalid, removing it"
+        elif echo "$api_output" | grep -q "HTTP 401"; then
+            debug_log "Cached token rejected with HTTP 401, removing it"
             rm -f "$cache_file"
+        else
+            debug_log "Token check failed transiently (exit $api_exit), keeping cached token: $api_output"
+            echo "$cached_token"
+            return 0
         fi
     fi
-    
+
     # Check if there's an in-progress device flow
     if [ -f "$state_file" ]; then
-        local state_age=$(($(date +%s) - $(stat -f %m "$state_file" 2>/dev/null || stat -c %Y "$state_file" 2>/dev/null)))
-        
-        # If state file is less than 15 minutes old
-        if [ $state_age -lt 900 ]; then
+        local state_age
+        state_age=$(($(date +%s) - $(stat -f %m "$state_file" 2>/dev/null || stat -c %Y "$state_file" 2>/dev/null)))
+
+        # The flow expires when GitHub says it does (expires_in, measured
+        # from the state file's creation); fall back to 15 minutes if the
+        # field is missing or malformed.
+        local flow_expires_in
+        flow_expires_in=$(jq -r '.expires_in // empty' "$state_file" 2>/dev/null)
+        case "$flow_expires_in" in
+            ''|*[!0-9]*) flow_expires_in=900 ;;
+        esac
+
+        if [ "$state_age" -lt "$flow_expires_in" ]; then
             debug_log "Found recent device flow state (${state_age}s old)"
-            
-            # Check if there's a status file indicating completion
+
+            local flow_status=""
             if [ -f "${state_file}.status" ]; then
-                local status
-                status=$(cat "${state_file}.status")
-                
-                if [ "$status" = "completed" ]; then
-                    # Token should have been saved, try again
-                    rm -f "${state_file}.status"
-                    if [ -f "$cache_file" ]; then
-                        cached_token=$(cat "$cache_file")
-                        echo "$cached_token"
-                        return 0
-                    fi
-                elif [[ "$status" == "failed:"* ]]; then
-                    echo "[ERROR] Previous authentication failed: ${status#failed: }" >&2
-                    rm -f "$state_file" "${state_file}.status"
-                elif [ "$status" = "expired" ]; then
-                    echo "[ERROR] Previous authentication expired" >&2
-                    rm -f "$state_file" "${state_file}.status"
-                fi
+                flow_status=$(cat "${state_file}.status")
+            fi
+
+            if [[ "$flow_status" == "failed:"* ]]; then
+                echo "[ERROR] Previous authentication failed: ${flow_status#failed: }" >&2
+                rm -f "$state_file" "${state_file}.status"
+            elif [ "$flow_status" = "expired" ]; then
+                echo "[ERROR] Previous authentication expired" >&2
+                rm -f "$state_file" "${state_file}.status"
             else
-                # Still in progress, show the existing code
-                local user_code verification_uri
-                user_code=$(jq -r '.user_code' "$state_file" 2>/dev/null)
-                verification_uri=$(jq -r '.verification_uri' "$state_file" 2>/dev/null)
-                
-                if [ -n "$user_code" ] && [ -n "$verification_uri" ]; then
-                    echo "" >&2
-                    echo "=================================================================" >&2
-                    echo "  GitHub App Authentication Already In Progress" >&2
-                    echo "=================================================================" >&2
-                    echo "" >&2
-                    echo "  AI tool detected: $AI_TOOL" >&2
-                    echo "" >&2
-                    echo "  Please complete the authorization:" >&2
-                    echo "" >&2
-                    echo "  For humans:" >&2
-                    echo "  1. Visit: $verification_uri" >&2
-                    echo "  2. Enter code: $user_code" >&2
-                    echo "" >&2
-                    echo "  For AI agents - run these commands:" >&2
-                    echo "  echo '$user_code' | pbcopy" >&2
-                    echo "  open '$verification_uri'" >&2
-                    echo "" >&2
-                    echo "  Authentication will complete in the background." >&2
-                    echo "  Try your command again in a few seconds." >&2
-                    echo "" >&2
-                    return 1
+                # The flow is still live. (A stale "completed" marker from an
+                # EARLIER flow can sit next to a fresh pending state file —
+                # the mint path used to leave it behind. It must not cause
+                # this flow to be abandoned: the human may be typing this
+                # very code into github.com/login/device right now.)
+                #
+                # Give the broker one foreground poll: if the human already
+                # authorized, we get the token right here instead of racing
+                # the background poller.
+                local pending_token poll_result
+                pending_token=$(poll_pending_flow_once "$state_file" "$cache_file")
+                poll_result=$?
+
+                if [ "$poll_result" -eq 0 ]; then
+                    echo "$pending_token"
+                    return 0
                 fi
+
+                if [ "$poll_result" -eq 1 ]; then
+                    # Still pending: re-show the EXISTING code. Never mint a
+                    # new flow while this one is live — that rotates the code
+                    # away under the human's fingers.
+                    local user_code verification_uri
+                    user_code=$(jq -r '.user_code // empty' "$state_file" 2>/dev/null)
+                    verification_uri=$(jq -r '.verification_uri // empty' "$state_file" 2>/dev/null)
+
+                    if [ -n "$user_code" ] && [ -n "$verification_uri" ]; then
+                        echo "" >&2
+                        echo "=================================================================" >&2
+                        echo "  GitHub App Authentication Already In Progress" >&2
+                        echo "=================================================================" >&2
+                        echo "" >&2
+                        echo "  AI tool detected: $AI_TOOL" >&2
+                        echo "" >&2
+                        echo "  Please complete the authorization:" >&2
+                        echo "" >&2
+                        echo "  For humans:" >&2
+                        echo "  1. Visit: $verification_uri" >&2
+                        echo "  2. Enter code: $user_code" >&2
+                        echo "" >&2
+                        echo "  For AI agents - run these commands:" >&2
+                        echo "  echo '$user_code' | pbcopy" >&2
+                        echo "  open '$verification_uri'" >&2
+                        echo "" >&2
+                        echo "  Authentication will complete in the background." >&2
+                        echo "  Try your command again in a few seconds." >&2
+                        echo "" >&2
+                        return 1
+                    fi
+
+                    # State file is unreadable or corrupt — only then is
+                    # replacing the flow the right call.
+                    debug_log "Pending device flow state is corrupt, discarding"
+                    rm -f "$state_file" "${state_file}.status"
+                fi
+                # poll_result 2: the flow was denied/expired at the broker;
+                # state has been cleaned up — fall through and mint anew.
             fi
         else
-            debug_log "Device flow state is too old (${state_age}s), removing"
+            debug_log "Device flow state expired after ${flow_expires_in}s (${state_age}s old), removing"
             rm -f "$state_file" "${state_file}.status"
         fi
     fi
-    
-    # No valid cached token or in-progress flow, start new auth flow
+
+    # No valid cached token or live flow: mint a new one. Clear any stale
+    # status marker first so it cannot poison the next invocation's view of
+    # the flow we are about to create.
+    rm -f "${state_file}.status"
+
     debug_log "Starting new authentication flow"
     
     # Use device flow for CLI (doesn't require browser redirect)

--- a/test_device_flow_reuse.sh
+++ b/test_device_flow_reuse.sh
@@ -1,0 +1,357 @@
+#!/bin/bash
+
+# Integration tests for device-flow state handling in get_cached_token().
+#
+# Regression suite for the code-rotation bug: every unauthorized invocation
+# minted a NEW device flow instead of reusing the pending one, so the human's
+# just-authorized code was burned over and over. Two interlocking causes:
+#
+#   1. Token validation treated ANY `gh api user` failure (rate limit 403,
+#      network error) as "token invalid" and deleted the freshly exchanged
+#      token from the cache.
+#   2. The mint path left a stale "${state_file}.status" == "completed"
+#      marker behind; the next invocation consumed it, found no cache token,
+#      and fell through to mint again — rotating the still-pending flow.
+#
+# All tests are hermetic: a fake gh (AI_ALIGNED_GH_BIN) plays GitHub, a fake
+# curl on PATH plays the as-a-bot broker, and each test gets a fresh HOME.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WRAPPER="$SCRIPT_DIR/executable_gh"
+
+PASS=0
+FAIL=0
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+TMP_DIR=$(mktemp -d)
+# Mint tests spawn detached background pollers whose command lines reference
+# $TMP_DIR paths; kill only those (never the user's real wrapper pollers).
+trap 'pkill -f "$TMP_DIR" 2>/dev/null; rm -rf "$TMP_DIR"' EXIT
+
+FAKE_BIN="$TMP_DIR/bin"
+mkdir -p "$FAKE_BIN"
+
+# --- Fake gh -----------------------------------------------------------------
+# `api user` behavior is driven by $FAKE_BROKER_DIR/gh_api_user_mode:
+#   ok (default)  -> HTTP 200, token accepted
+#   rate_limited  -> the exact failure mode observed live: a valid token that
+#                    cannot be verified because the user's primary rate limit
+#                    is exhausted (HTTP 403)
+#   unauthorized  -> HTTP 401, token is definitively dead
+cat > "$FAKE_BIN/gh" <<'FAKEGH'
+#!/bin/bash
+if [ "$1" = "api" ] && [ "$2" = "user" ]; then
+    mode=$(cat "$FAKE_BROKER_DIR/gh_api_user_mode" 2>/dev/null || echo ok)
+    case "$mode" in
+        ok) echo '{"login":"testuser"}'; exit 0 ;;
+        rate_limited)
+            echo "gh: API rate limit exceeded for user ID 12345. (HTTP 403)" >&2
+            exit 1 ;;
+        unauthorized)
+            echo "gh: Bad credentials (HTTP 401)" >&2
+            exit 1 ;;
+    esac
+fi
+if [ "$1" = "auth" ] && [ "$2" = "token" ]; then
+    echo "ghp_PERSONAL_TOKEN"
+    exit 0
+fi
+if [ "$1" = "api" ]; then
+    echo '{}'
+    exit 0
+fi
+exit 0
+FAKEGH
+chmod +x "$FAKE_BIN/gh"
+
+# --- Fake curl (the as-a-bot broker) -----------------------------------------
+# /user-token/start: mints flow N -> user_code MINT-N, counts mints in
+#   $FAKE_BROKER_DIR/start_count so tests can assert "no rotation happened".
+# /user-token/poll:  replays $FAKE_BROKER_DIR/poll_response (default:
+#   authorization_pending) and logs each polled payload to poll_log.
+cat > "$FAKE_BIN/curl" <<'FAKECURL'
+#!/bin/bash
+url=""
+prev=""
+for a in "$@"; do
+    case "$a" in
+        http://*|https://*) url="$a" ;;
+    esac
+    if [ "$prev" = "-d" ]; then
+        payload="$a"
+    fi
+    prev="$a"
+done
+case "$url" in
+    */user-token/start)
+        n=$(cat "$FAKE_BROKER_DIR/start_count" 2>/dev/null || echo 0)
+        n=$((n + 1))
+        echo "$n" > "$FAKE_BROKER_DIR/start_count"
+        printf '{"device_code":"minted-devcode-%s","user_code":"MINT-%s","verification_uri":"https://github.com/login/device","expires_in":900,"interval":1}\n' "$n" "$n"
+        ;;
+    */user-token/poll)
+        echo "${payload:-}" >> "$FAKE_BROKER_DIR/poll_log"
+        cat "$FAKE_BROKER_DIR/poll_response" 2>/dev/null || echo '{"error":"authorization_pending"}'
+        ;;
+    *)
+        echo '{}'
+        ;;
+esac
+FAKECURL
+chmod +x "$FAKE_BIN/curl"
+
+# --- Per-test environment ----------------------------------------------------
+TESTN=0
+ISOLATED_HOME=""
+BROKER_DIR=""
+CACHE_FILE=""
+STATE_FILE=""
+
+new_env() {
+    TESTN=$((TESTN + 1))
+    ISOLATED_HOME="$TMP_DIR/home-$TESTN"
+    BROKER_DIR="$TMP_DIR/broker-$TESTN"
+    mkdir -p "$ISOLATED_HOME/.cache/ai-aligned-gh" \
+        "$ISOLATED_HOME/.config/ai-aligned-gh/auth" \
+        "$BROKER_DIR"
+    CACHE_FILE="$ISOLATED_HOME/.cache/ai-aligned-gh/token"
+    STATE_FILE="$ISOLATED_HOME/.config/ai-aligned-gh/auth/device_flow.json"
+}
+
+seed_pending_flow() { # $1 = device_code, $2 = user_code, $3 = expires_in (default 900)
+    printf '{"device_code":"%s","user_code":"%s","verification_uri":"https://github.com/login/device","expires_in":%s,"interval":1}\n' \
+        "$1" "$2" "${3:-900}" > "$STATE_FILE"
+    chmod 600 "$STATE_FILE"
+}
+
+age_state_file() { # $1 = seconds to push the state file into the past
+    perl -e 'my $t = time - $ARGV[1]; utime($t, $t, $ARGV[0]) or die "utime: $!"' \
+        "$STATE_FILE" "$1"
+}
+
+start_count() {
+    cat "$BROKER_DIR/start_count" 2>/dev/null || echo 0
+}
+
+# AI detected (DROID_CLI=1), fake gh, fake curl as broker. The broker URL is
+# a non-resolvable sentinel: only the fake curl ever sees it.
+run_ai() {
+    env -i \
+        HOME="$ISOLATED_HOME" \
+        PATH="$FAKE_BIN:/opt/homebrew/bin:/usr/bin:/bin" \
+        AI_ALIGNED_GH_BIN="$FAKE_BIN/gh" \
+        AS_A_BOT_URL="http://fake-broker.invalid" \
+        FAKE_BROKER_DIR="$BROKER_DIR" \
+        DROID_CLI=1 \
+        bash "$WRAPPER" "$@"
+}
+
+echo "=== Integration: device flow reuse (no code rotation) ==="
+
+# -----------------------------------------------------------------------------
+echo ""
+echo "--- Pending flow is reused, not rotated ---"
+new_env
+seed_pending_flow "devcode-pending" "AAAA-1111"
+err=$(run_ai auth token 2>&1 >/dev/null)
+rc=$?
+if [ "$rc" -ne 0 ] && echo "$err" | grep -q "AAAA-1111"; then
+    pass "existing user code is shown again"
+else
+    fail "expected existing code AAAA-1111 in output, got rc=$rc: $err"
+fi
+if [ "$(start_count)" = "0" ]; then
+    pass "no new flow was minted"
+else
+    fail "a pending flow was rotated ($(start_count) mint(s))"
+fi
+if grep -q "devcode-pending" "$STATE_FILE" 2>/dev/null; then
+    pass "pending state file is untouched"
+else
+    fail "pending state file was replaced or removed"
+fi
+
+# -----------------------------------------------------------------------------
+echo ""
+echo "--- Stale 'completed' marker next to a pending flow: still no rotation ---"
+# The mint path used to leave device_flow.json.status == "completed" behind
+# from an earlier flow. With no cache token, the old code consumed the marker
+# and minted a brand-new flow, burning the pending code.
+new_env
+seed_pending_flow "devcode-pending2" "BBBB-2222"
+echo "completed" > "$STATE_FILE.status"
+err=$(run_ai auth token 2>&1 >/dev/null)
+rc=$?
+if [ "$rc" -ne 0 ] && echo "$err" | grep -q "BBBB-2222"; then
+    pass "pending code survives a stale completed marker"
+else
+    fail "expected pending code BBBB-2222, got rc=$rc: $err"
+fi
+if [ "$(start_count)" = "0" ]; then
+    pass "stale completed marker does not trigger a mint"
+else
+    fail "stale completed marker rotated the pending flow ($(start_count) mint(s))"
+fi
+
+# -----------------------------------------------------------------------------
+echo ""
+echo "--- Completed exchange + rate-limited validation: token is picked up ---"
+# The background poller stored the token and wrote "completed"; the user's
+# primary rate limit is exhausted so `gh api user` returns HTTP 403. The
+# token must be returned, not deleted.
+new_env
+printf 'ghu_EXCHANGED_TOKEN' > "$CACHE_FILE"
+chmod 600 "$CACHE_FILE"
+echo "completed" > "$STATE_FILE.status"   # poller already removed $STATE_FILE
+echo "rate_limited" > "$BROKER_DIR/gh_api_user_mode"
+out=$(run_ai auth token 2>/dev/null)
+rc=$?
+if [ "$rc" -eq 0 ] && [ "$out" = "ghu_EXCHANGED_TOKEN" ]; then
+    pass "rate-limited token is still returned"
+else
+    fail "expected ghu_EXCHANGED_TOKEN rc=0, got '$out' rc=$rc"
+fi
+if [ -f "$CACHE_FILE" ]; then
+    pass "cached token survives a rate-limited validation"
+else
+    fail "cached token was deleted on a rate-limited validation"
+fi
+if [ ! -f "$STATE_FILE.status" ]; then
+    pass "completed marker is consumed"
+else
+    fail "completed marker was left behind"
+fi
+if [ "$(start_count)" = "0" ]; then
+    pass "no flow is minted while a usable token exists"
+else
+    fail "a usable token was discarded and a flow minted ($(start_count) mint(s))"
+fi
+
+# -----------------------------------------------------------------------------
+echo ""
+echo "--- Completed exchange + valid token: token is picked up ---"
+new_env
+printf 'ghu_VALID_TOKEN' > "$CACHE_FILE"
+chmod 600 "$CACHE_FILE"
+echo "completed" > "$STATE_FILE.status"
+out=$(run_ai auth token 2>/dev/null)
+rc=$?
+if [ "$rc" -eq 0 ] && [ "$out" = "ghu_VALID_TOKEN" ]; then
+    pass "completed exchange yields the token on the next invocation"
+else
+    fail "expected ghu_VALID_TOKEN rc=0, got '$out' rc=$rc"
+fi
+
+# -----------------------------------------------------------------------------
+echo ""
+echo "--- HTTP 401 still invalidates the cached token ---"
+new_env
+printf 'ghu_DEAD_TOKEN' > "$CACHE_FILE"
+chmod 600 "$CACHE_FILE"
+echo "unauthorized" > "$BROKER_DIR/gh_api_user_mode"
+out=$(run_ai auth token 2>/dev/null)
+rc=$?
+if [ "$rc" -ne 0 ] && [ ! -f "$CACHE_FILE" ]; then
+    pass "definitively dead token is removed"
+else
+    fail "expected 401 token removal, got '$out' rc=$rc cache_present=$([ -f "$CACHE_FILE" ] && echo yes || echo no)"
+fi
+if [ "$(start_count)" = "1" ]; then
+    pass "a fresh flow is minted after a 401"
+else
+    fail "expected exactly one mint after 401, got $(start_count)"
+fi
+
+# -----------------------------------------------------------------------------
+echo ""
+echo "--- Already-authorized pending flow: foreground poll picks up the token ---"
+new_env
+seed_pending_flow "devcode-authorized" "CCCC-3333"
+echo '{"access_token":"ghu_FOREGROUND_PICKUP","token_type":"bearer"}' > "$BROKER_DIR/poll_response"
+out=$(run_ai auth token 2>/dev/null)
+rc=$?
+if [ "$rc" -eq 0 ] && [ "$out" = "ghu_FOREGROUND_PICKUP" ]; then
+    pass "authorized flow yields a token immediately"
+else
+    fail "expected ghu_FOREGROUND_PICKUP rc=0, got '$out' rc=$rc"
+fi
+if grep -q "devcode-authorized" "$BROKER_DIR/poll_log" 2>/dev/null; then
+    pass "the EXISTING device code was polled"
+else
+    fail "the pending device code was never polled"
+fi
+if [ ! -f "$STATE_FILE" ]; then
+    pass "state file is cleaned up after pickup"
+else
+    fail "state file left behind after pickup"
+fi
+if [ "$(start_count)" = "0" ]; then
+    pass "no rotation on pickup"
+else
+    fail "pickup minted a new flow ($(start_count) mint(s))"
+fi
+
+# -----------------------------------------------------------------------------
+echo ""
+echo "--- Denied flow is replaced by a fresh mint ---"
+new_env
+seed_pending_flow "devcode-denied" "DDDD-4444"
+echo '{"error":"access_denied"}' > "$BROKER_DIR/poll_response"
+err=$(run_ai auth token 2>&1 >/dev/null)
+rc=$?
+if [ "$rc" -ne 0 ] && [ "$(start_count)" = "1" ]; then
+    pass "denied flow triggers exactly one new mint"
+else
+    fail "expected one mint after denial, got $(start_count) rc=$rc"
+fi
+if echo "$err" | grep -q "MINT-1"; then
+    pass "the NEW code is shown after denial"
+else
+    fail "new code not shown after denial: $err"
+fi
+
+# -----------------------------------------------------------------------------
+echo ""
+echo "--- Flow expired per its own expires_in is re-minted ---"
+# expires_in 300, aged 400s: younger than the old hardcoded 900s cutoff, but
+# already dead at GitHub — keeping it would show a code that can never work.
+new_env
+seed_pending_flow "devcode-shortlived" "EEEE-5555" 300
+age_state_file 400
+err=$(run_ai auth token 2>&1 >/dev/null)
+rc=$?
+if [ "$(start_count)" = "1" ] && echo "$err" | grep -q "MINT-1"; then
+    pass "expired flow (per expires_in) is replaced"
+else
+    fail "expected re-mint of expired flow, got $(start_count) mint(s): $err"
+fi
+if echo "$err" | grep -q "EEEE-5555"; then
+    fail "dead code EEEE-5555 was shown to the user"
+else
+    pass "dead code is not shown"
+fi
+
+# -----------------------------------------------------------------------------
+echo ""
+echo "--- Flow older than the default 900s is re-minted ---"
+new_env
+seed_pending_flow "devcode-ancient" "FFFF-6666"
+age_state_file 1000
+err=$(run_ai auth token 2>&1 >/dev/null)
+rc=$?
+if [ "$(start_count)" = "1" ] && echo "$err" | grep -q "MINT-1"; then
+    pass "ancient flow is replaced"
+else
+    fail "expected re-mint of ancient flow, got $(start_count) mint(s): $err"
+fi
+
+# -----------------------------------------------------------------------------
+echo ""
+echo "=== Summary: $PASS passed, $FAIL failed ==="
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## The bug (observed live, 2026-08-17 ~14:49–14:57)

Every unauthorized invocation **rotated** the pending device flow instead of polling it, so the human could never win the race. Four codes were authorized and then burned in a row: `E8E7-D570` → `C38B-D6BE` → `90D5-3805` → `2E50-4563`. In the worst case, `device_flow.json.status` contained `completed` (the background poller had exchanged the token successfully), yet the very next invocation still reported "Authentication required" and minted a fresh flow.

## Root cause — two interlocking defects in `get_cached_token()`

1. **Any validation failure deleted the token.** `GH_TOKEN=… gh api user` was treated as a boolean: any non-zero exit meant "invalid token, remove cache". With the user's primary rate limit exhausted (HTTP 403), every freshly exchanged — perfectly valid — token was deleted the moment the next invocation tried to verify it.
2. **The `completed` marker was unreachable, and the mint path never cleaned it up.** The background poller deletes `device_flow.json` on success, but the `completed`-status handling was nested inside `if [ -f "$state_file" ]` — dead code in exactly the sequence it was written for. And because minting a new flow left the old `.status` file behind, a stale `completed` marker sitting next to a fresh pending flow made the next invocation consume the marker, find no cache token, and fall through to mint *again* — rotating the still-valid code the human was busy typing.

The two defects alternate: token exchanged → deleted as "invalid" (403) → mint → stale `completed` consumed → mint again → …, which is precisely the observed rotation.

## The fix

- **Only HTTP 401 invalidates the cached token.** Rate limits, network failures, and server errors keep it; the underlying `gh` call surfaces the real error.
- **`completed` is consumed before any state-file check**, without requiring the state file to still exist.
- **A pending, unexpired flow is never rotated.** Expiry honors the flow's own `expires_in` (measured from the state file's creation) instead of a hardcoded 900s. The invocation gives the broker one foreground poll — if the human already authorized, the token is picked up right there — and otherwise re-shows the **existing** user code.
- **A new flow is minted only when there is none**, or the existing one is expired, denied, or corrupt; minting clears any stale status marker.

## Tests

New hermetic suite `test_device_flow_reuse.sh` (fake `gh` + fake `curl` broker, isolated `HOME` per test, no network), wired into CI next to `test_timeout.sh`:

- pending-flow reuse (no rotation), incl. the stale-`completed`-marker case
- completed-exchange pickup under rate limit and with a valid token
- HTTP 401 still invalidates and re-mints
- foreground poll picks up an already-authorized flow (and polls the *existing* device code)
- denied flow → exactly one fresh mint
- expiry per the flow's own `expires_in`, plus the 900s default

21 assertions; **13 fail against the unfixed wrapper** (verified by reverting the fix), all 21 pass with it. Full pass: shellcheck (warning severity, all scripts), `test.sh`, `test_timeout.sh`, `test_safe_operation.sh`, `test_auth_token_attribution.sh`, `test_ai_detection.sh`, `test_pr_template_*.sh`, `test_impersonate.sh`, `test_image.sh`. (`test_priority_order.sh`'s Zed case fails identically on unmodified `main` when run under a claude ancestor process — pre-existing, unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvRbPciZoaWVbArSKTUo65
