### PR TITLE
Fix device-flow instructions that AI agents cannot run

### DIFF
--- a/executable_gh
+++ b/executable_gh
@@ -1820,9 +1820,13 @@ get_cached_token() {
                         echo "  1. Visit: $verification_uri" >&2
                         echo "  2. Enter code: $user_code" >&2
                         echo "" >&2
-                        echo "  For AI agents - run these commands:" >&2
-                        echo "  echo '$user_code' | pbcopy" >&2
-                        echo "  open '$verification_uri'" >&2
+                        echo "  For AI agents - relay, do not automate:" >&2
+                        echo "  A sandboxed agent shell can reach neither the clipboard nor the" >&2
+                        echo "  browser (pbcopy exits 1, open reports procNotFound), and there is" >&2
+                        echo "  no pre-filled URL - GitHub does not support user_code as a query" >&2
+                        echo "  parameter. Show the user the URL and code above verbatim and ask" >&2
+                        echo "  them to authorize. Only if your shell is NOT sandboxed:" >&2
+                        echo "    printf '%s' '$user_code' | pbcopy && open '$verification_uri'" >&2
                         echo "" >&2
                         echo "  Authentication will complete in the background." >&2
                         echo "  Try your command again in a few seconds." >&2
@@ -1904,9 +1908,13 @@ get_cached_token() {
     echo "  1. Visit: $verification_uri" >&2
     echo "  2. Enter code: $user_code" >&2
     echo "" >&2
-    echo "  For AI agents - run these commands:" >&2
-    echo "  echo '$user_code' | pbcopy" >&2
-    echo "  open '$verification_uri'" >&2
+    echo "  For AI agents - relay, do not automate:" >&2
+    echo "  A sandboxed agent shell can reach neither the clipboard nor the" >&2
+    echo "  browser (pbcopy exits 1, open reports procNotFound), and there is" >&2
+    echo "  no pre-filled URL - GitHub does not support user_code as a query" >&2
+    echo "  parameter. Show the user the URL and code above verbatim and ask" >&2
+    echo "  them to authorize. Only if your shell is NOT sandboxed:" >&2
+    echo "    printf '%s' '$user_code' | pbcopy && open '$verification_uri'" >&2
     echo "" >&2
     echo "  Authentication will complete in the background." >&2
     echo "  Try your command again after authorizing." >&2


### PR DESCRIPTION
## Problem

The device-flow prompt tells AI agents to run two commands:

```sh
echo '$user_code' | pbcopy
open '$verification_uri'
```

Both fail in a sandboxed agent shell. The macOS pasteboard and LaunchServices are Mach services, and seatbelt denies the lookup:

| command | sandboxed agent shell |
|---|---|
| `printf X \| pbcopy` | exit 1, no output |
| `osascript -e 'set the clipboard to "X"'` | `-10006`, "Connection Invalid ... hiservices-xpcservice" |
| `open '<url>'` | `-600 procNotFound` |

There is no in-sandbox workaround — no CLI, no AppleScript, no temp-file trick reaches the pasteboard server. So both lines are broken for exactly the audience they are written for: the agent runs two commands that fail, and the user never gets the code.

## Why not a pre-filled URL

The obvious fix is a URL carrying the code, so no clipboard is needed. It does not exist:

- GitHub's device-flow response omits RFC 8628's optional `verification_uri_complete`. Observed response fields: `device_code`, `user_code`, `verification_uri`, `expires_in`, `interval`.
- `https://github.com/login/device?user_code=XXXX-XXXX` does not pre-fill the field (checked in a browser, with and without `skip_account_picker=true`).

The commit message records this so the next reader doesn't re-derive and ship it.

## Fix

Tell agents to do the one thing that works — relay the code and URL to the user verbatim:

```
  For AI agents - relay, do not automate:
  A sandboxed agent shell can reach neither the clipboard nor the
  browser (pbcopy exits 1, open reports procNotFound), and there is
  no pre-filled URL - GitHub does not support user_code as a query
  parameter. Show the user the URL and code above verbatim and ask
  them to authorize. Only if your shell is NOT sandboxed:
    printf '%s' '9EC1-502E' | pbcopy && open 'https://github.com/login/device'
```

`pbcopy`/`open` survive as an explicitly conditional fallback for unsandboxed shells, with `printf` instead of `echo` so the trailing newline no longer contaminates the copied code.

Applied to both prompt sites: the in-progress flow and the new flow.

## Testing

- `bash -n executable_gh` passes; `shellcheck -S error` clean.
- Rendered both blocks with real values to confirm interpolation and quoting.
- Exercised the real device flow end to end through this wrapper: relayed the code by hand, authorization succeeded, `gh pr create` then worked.
- `test.sh`: same result as `main` — the one failure ("Repository detection failed") reproduces on an unmodified `main` in this sandbox and is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)