### PR TITLE
Fix Linux state-file age check broken by stat -f

### DIFF
--- a/executable_gh
+++ b/executable_gh
@@ -1744,8 +1744,17 @@ get_cached_token() {
 
     # Check if there's an in-progress device flow
     if [ -f "$state_file" ]; then
-        local state_age
-        state_age=$(($(date +%s) - $(stat -f %m "$state_file" 2>/dev/null || stat -c %Y "$state_file" 2>/dev/null)))
+        local state_age state_mtime
+        # GNU stat -f means "filesystem status" and SUCCEEDS, so a
+        # `stat -f %m || stat -c %Y` fallback never reaches the fallback on
+        # Linux and feeds block counts into the arithmetic. Dispatch on the
+        # OS instead, as the cached-token check above already does.
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            state_mtime=$(stat -f %m "$state_file" 2>/dev/null)
+        else
+            state_mtime=$(stat -c %Y "$state_file" 2>/dev/null)
+        fi
+        state_age=$(($(date +%s) - ${state_mtime:-0}))
 
         # The flow expires when GitHub says it does (expires_in, measured
         # from the state file's creation); fall back to 15 minutes if the


### PR DESCRIPTION
## Problem

The Test workflow has been failing on `main` since #70 landed ([run](https://github.com/ai-ecoverse/ai-aligned-gh/actions/runs/32467803886/job/96728043299)). `get_cached_token` computes the device-flow state age with:

```sh
stat -f %m "$state_file" 2>/dev/null || stat -c %Y "$state_file" 2>/dev/null
```

On BSD/macOS, `stat -f %m` prints the mtime. On Linux, GNU `stat -f` means **"display filesystem status"** and **succeeds** — so the `||` fallback is never reached, and the filesystem's block and inode counts land in the arithmetic:

```
executable_gh: line 1748: 1787304700 -   File: "/tmp/.../device_flow.json"
    ID: 542238b4501be5b9 Namelen: 255     Type: ext2/ext3
    Blocks: Total: 37815964   Free: 22580003  ...
    ...: syntax error in expression (error token is ": "...")
```

Every age comparison then breaks, so pending flows are neither reused nor re-minted — the exact behavior #70 set out to fix, silently undone on Linux. It passes on macOS because the BSD branch happens to be correct, which is why local runs are green (21/21 here).

## Fix

Dispatch on `$OSTYPE`, matching the pattern the cached-token check at line 589 already uses:

```sh
if [[ "$OSTYPE" == "darwin"* ]]; then
    state_mtime=$(stat -f %m "$state_file" 2>/dev/null)
else
    state_mtime=$(stat -c %Y "$state_file" 2>/dev/null)
fi
state_age=$(($(date +%s) - ${state_mtime:-0}))
```

A missing mtime defaults to `0`, so an unreadable state file reads as ancient and gets re-minted rather than erroring.

## Testing

- `bash -n` and `shellcheck -S error` clean.
- `test_device_flow_reuse.sh`: 21 passed, 0 failed locally (macOS).
- Linux CI on this PR is the real verification — it is the only environment that exercises the broken branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)